### PR TITLE
fix(image_gen): surface OpenAI API error bodies in 4xx responses

### DIFF
--- a/image_gen/renderers/openai_renderer.py
+++ b/image_gen/renderers/openai_renderer.py
@@ -96,7 +96,10 @@ class OpenAIRenderer:
                 },
                 json=body,
             )
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"OpenAI /v1/images/generations {resp.status_code}: {resp.text}"
+                )
             return resp.json()
 
     async def _render_edits(self, request: RenderRequest, size: str) -> dict:
@@ -125,5 +128,8 @@ class OpenAIRenderer:
                 data=data,
                 files=files,
             )
-            resp.raise_for_status()
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"OpenAI /v1/images/edits {resp.status_code}: {resp.text}"
+                )
             return resp.json()


### PR DESCRIPTION
## Summary
- `raise_for_status()` discards the response body — so a 4xx from OpenAI surfaces as `HTTPStatusError` with no detail about *why*.
- Tonight's investigation of #186 hit this directly: journal had "got a 400" but nothing else, and verifying any hypothesis required live (paid) API calls.
- Replaces the `raise_for_status()` calls in both `_render_generations` and `_render_edits` with a status check that raises `RuntimeError` carrying `resp.text`.

## Behaviour change
- Previously: `httpx.HTTPStatusError: Client error '400 Bad Request'` (no body).
- Now: `RuntimeError: OpenAI /v1/images/edits 400: {"error":{"message": "...", ...}}`.
- Same trigger condition (any 4xx/5xx). Successful responses unchanged.

## Test plan
- [x] Existing imports still work — only the failure branch changes.
- [ ] Next time anything in the image pipeline 400s, the error should now contain OpenAI's explanation. (Will validate naturally as #186 follow-ups land.)

Closes part of #186 (the visibility gap, not the underlying scenario-specific bug — that still needs Caia's exact failing prompt to repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)