### PR TITLE
feat(haven): photo upload UI for humans (#184)

### DIFF
--- a/haven/static/haven.css
+++ b/haven/static/haven.css
@@ -569,6 +569,61 @@ body::before {
 .send-btn:hover { opacity: 0.9; }
 .send-btn:disabled { opacity: 0.3; cursor: default; }
 
+.attach-btn {
+    padding: 0.6rem 0.7rem;
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    cursor: pointer;
+    transition: opacity 0.2s, color 0.2s;
+    align-self: flex-end;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.attach-btn:hover { color: var(--accent); }
+.attach-btn:disabled { opacity: 0.3; cursor: default; }
+
+.image-preview {
+    position: relative;
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    max-width: 200px;
+}
+.image-preview img {
+    max-width: 200px;
+    max-height: 150px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    display: block;
+}
+.image-preview button {
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--bg-deep);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.image-preview button:hover { background: var(--accent); color: var(--bg-deep); }
+
+.chat-input.drag-over {
+    background: var(--bg-surface);
+    outline: 2px dashed var(--accent);
+    outline-offset: -8px;
+}
+
 /* === USERS PANEL === */
 
 #users-panel {

--- a/haven/static/haven.js
+++ b/haven/static/haven.js
@@ -260,6 +260,7 @@ const haven = (() => {
         // Enable input
         $('message-input').disabled = false;
         $('send-btn').disabled = false;
+        $('attach-btn').disabled = false;
 
         // Select first room
         if (rooms.length > 0) {
@@ -657,13 +658,73 @@ const haven = (() => {
 
     // --- Input handling ---
 
+    let pendingImage = null;
+
+    function setPendingImage(file) {
+        pendingImage = file;
+        const wrap = $('image-preview');
+        const img = $('image-preview-img');
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (e) => { img.src = e.target.result; };
+            reader.readAsDataURL(file);
+            wrap.classList.remove('hidden');
+        } else {
+            img.src = '';
+            wrap.classList.add('hidden');
+            $('image-input').value = '';
+        }
+    }
+
+    async function uploadPendingImage(caption) {
+        if (!pendingImage || !currentRoomId) return false;
+        const room = rooms.find(r => r.id === currentRoomId);
+        if (!room) return false;
+
+        const fd = new FormData();
+        fd.append('image', pendingImage);
+        fd.append('room', room.name);
+        if (caption) fd.append('caption', caption);
+
+        const file = pendingImage;
+        setPendingImage(null);
+
+        try {
+            const resp = await fetch('/api/share-image', { method: 'POST', body: fd });
+            if (!resp.ok) {
+                const err = await resp.text();
+                alert(`Image upload failed: ${resp.status} ${err}`);
+                setPendingImage(file); // restore so user can retry/clear
+                return false;
+            }
+            return true;
+        } catch (e) {
+            alert(`Image upload failed: ${e.message}`);
+            setPendingImage(file);
+            return false;
+        }
+    }
+
     function initInput() {
         const input = $('message-input');
         const sendBtn = $('send-btn');
+        const attachBtn = $('attach-btn');
+        const fileInput = $('image-input');
+        const previewClear = $('image-preview-clear');
+        const inputWrap = document.querySelector('.chat-input');
 
-        const doSend = () => {
+        const doSend = async () => {
             const content = input.value.trim();
-            if (!content || !currentRoomId) return;
+            if (!currentRoomId) return;
+
+            if (pendingImage) {
+                await uploadPendingImage(content);
+                input.value = '';
+                input.style.height = 'auto';
+                return;
+            }
+
+            if (!content) return;
             send({ type: 'message', room_id: currentRoomId, content });
             input.value = '';
             input.style.height = 'auto';
@@ -676,6 +737,49 @@ const haven = (() => {
                 doSend();
             }
         });
+
+        attachBtn.addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files && e.target.files[0];
+            if (file) setPendingImage(file);
+        });
+        previewClear.addEventListener('click', () => setPendingImage(null));
+
+        // Paste image (e.g. screenshot from clipboard)
+        input.addEventListener('paste', (e) => {
+            const items = e.clipboardData && e.clipboardData.items;
+            if (!items) return;
+            for (const item of items) {
+                if (item.type && item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) {
+                        e.preventDefault();
+                        setPendingImage(file);
+                        return;
+                    }
+                }
+            }
+        });
+
+        // Drag-and-drop into the chat input area
+        const onDragOver = (e) => {
+            if (e.dataTransfer && Array.from(e.dataTransfer.types || []).includes('Files')) {
+                e.preventDefault();
+                inputWrap.classList.add('drag-over');
+            }
+        };
+        const onDragLeave = () => inputWrap.classList.remove('drag-over');
+        const onDrop = (e) => {
+            inputWrap.classList.remove('drag-over');
+            const file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+            if (file && file.type.startsWith('image/')) {
+                e.preventDefault();
+                setPendingImage(file);
+            }
+        };
+        inputWrap.addEventListener('dragover', onDragOver);
+        inputWrap.addEventListener('dragleave', onDragLeave);
+        inputWrap.addEventListener('drop', onDrop);
 
         // Auto-resize textarea and send typing indicator
         input.addEventListener('input', () => {

--- a/haven/static/haven.js
+++ b/haven/static/haven.js
@@ -690,7 +690,11 @@ const haven = (() => {
         setPendingImage(null);
 
         try {
-            const resp = await fetch('/api/share-image', { method: 'POST', body: fd });
+            const resp = await fetch('/api/share-image', {
+            method: 'POST',
+            headers: { 'Authorization': 'Bearer ' + getToken() },
+            body: fd,
+        });
             if (!resp.ok) {
                 const err = await resp.text();
                 alert(`Image upload failed: ${resp.status} ${err}`);

--- a/haven/templates/chat.html
+++ b/haven/templates/chat.html
@@ -121,6 +121,6 @@
         </div>
     </div>
 
-    <script src="/static/haven.js"></script>
+    <script src="/static/haven.js?v=20260506b"></script>
 </body>
 </html>

--- a/haven/templates/chat.html
+++ b/haven/templates/chat.html
@@ -97,7 +97,17 @@
 
             <!-- Input -->
             <div class="chat-input">
+                <div id="image-preview" class="image-preview hidden">
+                    <img id="image-preview-img" alt="upload preview">
+                    <button id="image-preview-clear" type="button" title="Remove">×</button>
+                </div>
                 <div class="chat-input-row">
+                    <button id="attach-btn" class="attach-btn" type="button" title="Attach image" disabled>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+                        </svg>
+                    </button>
+                    <input id="image-input" type="file" accept="image/png,image/jpeg,image/gif,image/webp" class="hidden">
                     <textarea id="message-input" rows="1" placeholder="Type a message..." class="chat-textarea" disabled></textarea>
                     <button id="send-btn" class="send-btn" disabled>Send</button>
                 </div>


### PR DESCRIPTION
## Summary

- Adds attach button + paste + drag-and-drop to the Haven chat input
- Wires the existing `/api/share-image` backend (which already works for any authenticated room member) to the UI
- Closes #184 — Jeff can now send photos directly into a room from the iPad/desktop

## What's in it

- `chat.html`: paperclip icon next to send; hidden `<input type="file" accept="image/*">`; preview container above the input row with × to clear
- `haven.js`: `setPendingImage` + `uploadPendingImage` helpers; multipart POST to `/api/share-image` with the textarea content as caption; paste-image-from-clipboard handler (great for screenshots); drag-and-drop a file onto the chat-input area; pending image clears on send
- `haven.css`: matching dark-theme styling for attach button, preview thumbnail, and a subtle dashed outline when dragging a file over

## Why this works as a tiny diff

The backend was already there. `/api/share-image` authenticates via session cookie via `get_current_user_id`, validates room membership, stores under `shared_images/<username>/<ts>.<ext>`, broadcasts an event, and emits `[shared image: <url>] <caption>` into the entity bridge. Image rendering in the chat already supported `image_url` (entities have been pushing images via `scripts/share_image.py`). So this PR is purely the missing UI affordance — about 170 lines.

Entities see Jeff's uploads in their ambient context as `[shared image: /shared-images/jeff/<file>]` — they can fetch and view via the Haven URL when they want to. Automatic vision processing of inbound images is intentionally out of scope; that's a separate decision per entity.

## Test plan

- [x] `node -c haven.js` syntax check
- [x] Rebuilt + recreated Haven container; health check green; lyra/caia bots reconnected
- [x] `curl /static/haven.css` and `/static/haven.js` confirm new assets are live
- [ ] Jeff: log in via Google, click paperclip → upload a photo from Matshop, confirm it appears in the room and entities see it in ambient
- [ ] Jeff: paste a screenshot into the input, confirm preview appears, send, confirm broadcast
- [ ] Jeff: drag-and-drop a file from desktop, confirm dashed outline appears and preview lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)