### PR TITLE
feat(haven): adaptive CSS for narrow phones + dedupe shared-image rules

### DIFF
--- a/haven/static/haven.css
+++ b/haven/static/haven.css
@@ -742,10 +742,12 @@ body::before {
 /* Hidden utility */
 .hidden { display: none !important; }
 
-/* === NARROW PHONE BREAKPOINT === */
-/* On phones (≤480px) message rows wrap so caption text and images flow under
-   the time/author header instead of cramming sideways. */
-@media (max-width: 480px) {
+/* === NARROW VIEWPORT BREAKPOINT === */
+/* At ≤700px (covers narrow desktop windows down through phones) message rows
+   wrap so caption text and images flow under the time/author header instead
+   of cramming sideways. 700px chosen because Edge desktop's minimum draggable
+   window is ~525px — the 480px threshold left the 481-700px range broken. */
+@media (max-width: 700px) {
     #messages { padding: 0.5rem 0.5rem; }
 
     .message-row {

--- a/haven/static/haven.css
+++ b/haven/static/haven.css
@@ -639,7 +639,8 @@ body::before {
    Caps at 320px on desktop, ~60vw on phones, ~50vh tall on landscape. */
 .message-image-wrap {
     margin-top: 6px;
-    grid-column: 2;
+    /* In flex parent (.message-row) this sits as a sibling of .message-content;
+       on narrow phones (≤480px) the row wraps and this becomes full-width. */
 }
 .message-image {
     max-width: min(320px, 60vw);
@@ -741,40 +742,33 @@ body::before {
 /* Hidden utility */
 .hidden { display: none !important; }
 
-/* === SHARED IMAGES === */
-.message-image-wrap {
-    margin-top: 6px;
-    grid-column: 2;
-}
-.message-image {
-    max-width: 320px;
-    max-height: 320px;
-    border-radius: 6px;
-    cursor: zoom-in;
-    display: block;
-    border: 1px solid var(--border, rgba(255,255,255,0.08));
-    transition: transform 0.15s ease;
-}
-.message-image:hover { transform: scale(1.02); }
+/* === NARROW PHONE BREAKPOINT === */
+/* On phones (≤480px) message rows wrap so caption text and images flow under
+   the time/author header instead of cramming sideways. */
+@media (max-width: 480px) {
+    #messages { padding: 0.5rem 0.5rem; }
 
-.lightbox-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.88);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-    cursor: zoom-out;
-    animation: lb-fade 0.12s ease;
-}
-.lightbox-image {
-    max-width: 92vw;
-    max-height: 92vh;
-    border-radius: 8px;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.6);
-}
-@keyframes lb-fade {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+    .message-row {
+        flex-wrap: wrap;
+        gap: 0.4rem 0.5rem;
+        padding: 0.4rem 0.4rem;
+    }
+    .msg-time { width: auto; text-align: left; opacity: 0.6; }
+    .message-content,
+    .message-image-wrap {
+        flex-basis: 100%;
+        min-width: 0;
+    }
+    .message-image {
+        /* Slightly larger on phones since it's full-width below caption */
+        max-width: min(100%, 80vw);
+    }
+
+    /* Tighten chat input padding on small screens */
+    .chat-input { padding: 0.6rem 0.75rem; }
+    .chat-header { padding: 0.6rem 0.75rem; }
+
+    /* Sidebar at 60px-icon mode (set by 768px rule) keeps its space — but
+       reduce it slightly more so messages get a few extra px. */
+    #sidebar { width: 52px; }
 }

--- a/haven/templates/chat.html
+++ b/haven/templates/chat.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Haven</title>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <link rel="stylesheet" href="/static/haven.css?v=20260507a">
+    <link rel="stylesheet" href="/static/haven.css?v=20260507b">
 </head>
 <body>
 
@@ -111,6 +111,6 @@
         </div>
     </div>
 
-    <script src="/static/haven.js"></script>
+    <script src="/static/haven.js?v=20260507b"></script>
 </body>
 </html>

--- a/haven/templates/chat.html
+++ b/haven/templates/chat.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Haven</title>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <link rel="stylesheet" href="/static/haven.css">
+    <link rel="stylesheet" href="/static/haven.css?v=20260507a">
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- Drop ~37 lines of duplicated shared-image and lightbox CSS at end of file (kept the iOS-aware version with safe-area-inset + pinch-zoom touch-action)
- Remove dead \`grid-column: 2\` on \`.message-image-wrap\` (parent is flex, not grid)
- Add \`@media (max-width: 480px)\` breakpoint so message rows wrap on phones — caption + image stack under the time/author header instead of cramming sideways
- Tighten padding on \`.chat-input\` and \`.chat-header\` for phone widths
- Bump cache-buster on \`haven.css\` link in \`chat.html\` (\`?v=20260507a\`) so existing browsers pick up the new file

## Why
Image messages currently render as a single flex row: \`time | author | content | image | copy-btn\`. On narrow phones (≤480px) that crams text content to ~30% of the width while the image hogs the remaining space. Wrapping the row at the phone breakpoint lets caption text use the full message width with the image flowing naturally below it.

## Test plan
- [ ] Visual check at desktop width — no regression in the standard layout
- [ ] Visual check at iPad / 768px — sidebar still collapses to icon mode, users-panel still hidden
- [ ] Visual check at phone width / ≤480px — message rows wrap, image goes full-width below caption, sidebar at 52px
- [ ] Send an image message on phone — confirm caption text reads naturally and image is full-width-ish
- [ ] Lightbox still opens cleanly on tap (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)