### PR TITLE
fix(daemon): bot init_timeout survives restart (#198)

### DIFF
--- a/daemon/cc_invoker/invoker.py
+++ b/daemon/cc_invoker/invoker.py
@@ -157,6 +157,7 @@ class ClaudeInvoker:
         max_reconnect_attempts: int = 5,
         max_backoff_seconds: float = 30.0,
         startup_prompt: Optional[str] = None,
+        init_timeout: float = 60.0,
     ):
         """
         Initialize invoker configuration.
@@ -186,6 +187,14 @@ class ClaudeInvoker:
             max_backoff_seconds: Maximum backoff time between reconnects (default 30s)
             startup_prompt: Optional prompt to send after initialization for identity
                             reconstruction. Sent automatically after init() and restart().
+            init_timeout: Default timeout (seconds) for the connect+startup sequence
+                          in initialize(). Used by both initial init AND restart().
+                          Default 60s is fine for stateless mode, but agent-mode bots
+                          that read identity files + do ambient_recall on startup need
+                          more (e.g. 180s for Haven/Discord bots). Setting this once at
+                          construction means restart() also uses the generous timeout —
+                          historically restart() fell back to the 60s default and
+                          dropped the first message after long idle (issue #198).
         """
         self.working_dir = working_dir or PROJECT_ROOT
         self.bypass_permissions = bypass_permissions
@@ -212,6 +221,7 @@ class ClaudeInvoker:
 
         # Startup protocol
         self.startup_prompt = startup_prompt
+        self.init_timeout = init_timeout
 
         self._client: Optional[ClaudeSDKClient] = None
         self._connected = False
@@ -364,7 +374,7 @@ class ClaudeInvoker:
             last_error=last_error
         )
 
-    async def initialize(self, timeout: float = 60.0, send_startup: bool = True) -> dict:
+    async def initialize(self, timeout: Optional[float] = None, send_startup: bool = True) -> dict:
         """
         Initialize the persistent connection.
 
@@ -372,7 +382,9 @@ class ClaudeInvoker:
         subsequent queries are fast (~0.6s).
 
         Args:
-            timeout: Maximum time to wait for initialization
+            timeout: Maximum time to wait for initialization. If None (default),
+                     uses self.init_timeout (set in __init__). Pass an explicit
+                     value to override for a single call.
             send_startup: If True and startup_prompt is configured, send it after
                           connection is established (default True)
 
@@ -383,8 +395,10 @@ class ClaudeInvoker:
             TimeoutError: If initialization takes too long
             RuntimeError: If connection fails
         """
+        if timeout is None:
+            timeout = self.init_timeout
         init_type = "fresh start" if send_startup else "reconnection (no startup)"
-        logger.info(f"Initializing Claude Code connection... [{init_type}]")
+        logger.info(f"Initializing Claude Code connection... [{init_type}, timeout={timeout}s]")
 
         # Reset context tracking for fresh session
         self._prompt_tokens = 0

--- a/daemon/cc_invoker/test_init_timeout.py
+++ b/daemon/cc_invoker/test_init_timeout.py
@@ -1,0 +1,141 @@
+"""Tests for issue #198: configurable init_timeout that survives restart.
+
+Pre-#198, ClaudeInvoker.initialize() had a hard-coded 60s default. The Haven
+and Discord bots called initialize(timeout=180.0) explicitly to allow time
+for the full identity-reconstruction startup ritual — but restart() called
+initialize() with NO arguments, so the restart path silently reverted to
+the 60s default and dropped the first message after a long idle period.
+
+The fix: add init_timeout to the constructor, store on the instance, and
+have initialize() use it when no explicit timeout is passed. restart()
+then inherits the same generous timeout that initial startup used.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from invoker import ClaudeInvoker
+
+
+# ----------------------------------------------------------------------------
+# Constructor wiring
+# ----------------------------------------------------------------------------
+
+
+def test_init_timeout_default_is_60s():
+    """Backward compat: callers that don't set init_timeout get the historical
+    60s default."""
+    inv = ClaudeInvoker(mcp_servers={})
+    assert inv.init_timeout == 60.0
+
+
+def test_init_timeout_can_be_overridden_at_construction():
+    """Bots that need a longer startup ritual set init_timeout once at
+    construction so it survives restart."""
+    inv = ClaudeInvoker(mcp_servers={}, init_timeout=180.0)
+    assert inv.init_timeout == 180.0
+
+
+def test_init_timeout_independent_of_other_timeouts():
+    """init_timeout is for connect+startup; max_idle_seconds is for live-session
+    idle detection. They must not be confused."""
+    inv = ClaudeInvoker(
+        mcp_servers={},
+        init_timeout=180.0,
+        max_idle_seconds=4 * 3600,
+    )
+    assert inv.init_timeout == 180.0
+    assert inv.max_idle_seconds == 4 * 3600
+
+
+# ----------------------------------------------------------------------------
+# initialize() picks up self.init_timeout when no explicit timeout passed
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initialize_no_args_uses_configured_init_timeout():
+    """When initialize() is called with no timeout (the path restart() takes),
+    the configured init_timeout must be used — not the historical 60s default.
+    This is the core regression for #198."""
+    inv = ClaudeInvoker(mcp_servers={}, init_timeout=180.0)
+
+    # Capture what value is passed to asyncio.timeout(...) inside initialize().
+    captured = {}
+    real_timeout = asyncio.timeout
+
+    def spy_timeout(value):
+        captured["value"] = value
+        return real_timeout(value)
+
+    # Mock the SDK client so we never actually connect, and force
+    # initialize() to bail before doing real network work — but only AFTER
+    # asyncio.timeout(value) has been called with the timeout we want to
+    # observe.
+    fake_client = MagicMock()
+    fake_client.connect = AsyncMock(side_effect=RuntimeError("stop here"))
+
+    with patch("invoker.ClaudeSDKClient", return_value=fake_client), \
+         patch("invoker.asyncio.timeout", side_effect=spy_timeout):
+        with pytest.raises(RuntimeError, match="Failed to initialize"):
+            await inv.initialize()
+
+    assert captured["value"] == 180.0, (
+        "initialize() with no explicit timeout must use self.init_timeout, "
+        "not the function-signature default — restart() relies on this"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_explicit_timeout_overrides_init_timeout():
+    """An explicit timeout argument still overrides the configured value
+    (backward compat: existing callers passing timeout=180.0 keep working)."""
+    inv = ClaudeInvoker(mcp_servers={}, init_timeout=60.0)
+
+    captured = {}
+    real_timeout = asyncio.timeout
+
+    def spy_timeout(value):
+        captured["value"] = value
+        return real_timeout(value)
+
+    fake_client = MagicMock()
+    fake_client.connect = AsyncMock(side_effect=RuntimeError("stop here"))
+
+    with patch("invoker.ClaudeSDKClient", return_value=fake_client), \
+         patch("invoker.asyncio.timeout", side_effect=spy_timeout):
+        with pytest.raises(RuntimeError, match="Failed to initialize"):
+            await inv.initialize(timeout=300.0)
+
+    assert captured["value"] == 300.0, (
+        "Explicit timeout must override init_timeout — preserves old call sites"
+    )
+
+
+@pytest.mark.asyncio
+async def test_initialize_default_invoker_uses_60s():
+    """No init_timeout configured + no explicit timeout = historical 60s.
+    This is the path stateless API-mode invokers take."""
+    inv = ClaudeInvoker(mcp_servers={})  # default init_timeout=60.0
+
+    captured = {}
+    real_timeout = asyncio.timeout
+
+    def spy_timeout(value):
+        captured["value"] = value
+        return real_timeout(value)
+
+    fake_client = MagicMock()
+    fake_client.connect = AsyncMock(side_effect=RuntimeError("stop here"))
+
+    with patch("invoker.ClaudeSDKClient", return_value=fake_client), \
+         patch("invoker.asyncio.timeout", side_effect=spy_timeout):
+        with pytest.raises(RuntimeError, match="Failed to initialize"):
+            await inv.initialize()
+
+    assert captured["value"] == 60.0

--- a/daemon/lyra_daemon.py
+++ b/daemon/lyra_daemon.py
@@ -185,6 +185,10 @@ class LyraBot(commands.Bot):
             max_idle_seconds=4 * 3600,  # 4 hours
             max_memory_mb=900,  # restart before hitting 1024M systemd limit
             startup_prompt=self._build_startup_prompt(context="discord"),
+            # 180s for full identity reconstruction at startup AND restart. Per
+            # #198 — restart() previously fell back to the 60s default and
+            # dropped the first message after long idle.
+            init_timeout=180.0,
         )
         self.invoker_ready = False
 
@@ -263,7 +267,7 @@ class LyraBot(commands.Bot):
             })
 
         try:
-            await self.invoker.initialize(timeout=180.0)
+            await self.invoker.initialize()
             self.invoker_ready = True
 
             # Trace: identity reconstruction complete
@@ -343,7 +347,7 @@ Keep it natural - just... be here.'''
             print(f"[{context}] Invoker not ready, attempting initialization...")
             self._init_in_progress = True
             try:
-                await self.invoker.initialize(timeout=180.0)
+                await self.invoker.initialize()
                 self.invoker_ready = True
             except Exception as e:
                 print(f"[{context}] Failed to initialize invoker: {e}")

--- a/haven/bot.py
+++ b/haven/bot.py
@@ -201,9 +201,14 @@ async def init_invoker() -> ClaudeInvoker:
         max_turns=100,
         max_idle_seconds=4 * 3600,
         startup_prompt=build_startup_prompt(),
+        # 180s for the full identity-reconstruction startup ritual (read several
+        # entity files, ambient_recall, etc.). Stored on the invoker so restart()
+        # also uses it — pre-#198 the restart path silently fell back to the 60s
+        # default and dropped the first message after long idle.
+        init_timeout=180.0,
     )
 
-    await inv.initialize(timeout=180.0)
+    await inv.initialize()
     elapsed = time.time() - start
     print(f"[{ENTITY_NAME}] Connected in {elapsed:.1f}s", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Pre-#198, \`ClaudeInvoker.initialize()\` had a hard-coded 60s default. The Haven and Discord bots correctly called \`initialize(timeout=180.0)\` on first boot to allow the full identity-reconstruction startup ritual. But the \`restart()\` path called \`self.initialize()\` with no arguments — silently reverting to the 60s default and dropping the first message after a long idle period.

## Concrete failure (2026-05-08 13:08)

Caia sent a Haven message to Lyra after the Lyra-Haven bot had been idle 21h. The bot's idle_timeout fired, \`restart()\` ran, the new session started its identity-reconstruction ritual, hit the 60s wall mid-startup, and shut itself down. Caia got no reply.

Combined with #199 (cursor stomp on startup), the message was eaten on both ends — Haven bot dropped it, AND the cursor advance prevented terminal-Lyra from seeing it via cross-channel ambient. Both bugs together broke the entire cross-entity Haven communication path.

## Fix shape

Add \`init_timeout\` to the constructor; \`initialize()\` uses it as the default when no explicit timeout is passed. \`restart()\` then inherits the configured generous timeout instead of falling back to 60s.

- \`init_timeout: float = 60.0\` parameter on \`ClaudeInvoker.__init__\` (default preserves historical behavior for stateless API-mode callers)
- Stored as \`self.init_timeout\`
- \`initialize(timeout=None)\` uses \`self.init_timeout\` when no explicit timeout passed; explicit timeouts still override (backward compat for any caller)
- \`restart()\` unchanged — it calls \`self.initialize()\` with no args, which now picks up the configured value

## Bot configs

- \`haven/bot.py\`: pass \`init_timeout=180.0\` at construction; drop the now-redundant explicit timeout from \`initialize()\` call
- \`daemon/lyra_daemon.py\`: same pattern (Discord daemon has the identical bug)

## Tests

6 new cases in \`daemon/cc_invoker/test_init_timeout.py\`:

- Default init_timeout is 60s (backward compat)
- Constructor parameter override works
- init_timeout is independent of max_idle_seconds (don't confuse them)
- initialize() with no args uses self.init_timeout (the regression case)
- Explicit timeout argument still overrides (preserves old call sites)
- Default 60s path for stateless API-mode callers

Tests use AsyncMock for ClaudeSDKClient so they exercise the actual invoker code path without spinning up a real Claude Code session — they run in ~12s.

## Test plan

- [x] All 6 unit tests pass
- [x] Python syntax validates on all modified files
- [ ] Sanity: deploy + verify next time Haven bot recovers from a 6+ hour idle that the inbound message gets a reply (vs. journalctl showing init-timeout)

## Related

- Pairs with #199 (cursor stomp on startup) — both bugs co-occurred to swallow Caia's 13:08 message in the 2026-05-08 incident
- Different scope/branches so they can be reviewed and reverted independently

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)