### PR TITLE
fix(auto-summarize): read unsummarized count from /tools/summary_stats

### DIFF
--- a/scripts/auto_summarize.py
+++ b/scripts/auto_summarize.py
@@ -37,18 +37,36 @@ PPS_PORT = os.environ.get("PPS_PORT", "8201")
 THRESHOLD = int(os.environ.get("SUMMARIZE_THRESHOLD", "100"))
 BATCH_SIZE = int(os.environ.get("SUMMARIZE_BATCH_SIZE", "50"))
 
+PROJECT_ROOT = Path(__file__).parent.parent
+ENTITY_PATH = Path(os.environ.get("ENTITY_PATH", PROJECT_ROOT / "entities" / "lyra"))
+
+
+def _load_entity_token() -> str:
+    token_file = ENTITY_PATH / ".entity_token"
+    try:
+        return token_file.read_text().strip()
+    except Exception as e:
+        logger.error(f"Failed to read entity token from {token_file}: {e}")
+        return ""
+
+
 def check_unsummarized_count() -> int:
-    """Query PPS for unsummarized message count."""
+    """Query PPS /tools/summary_stats for unsummarized message count."""
     try:
         import requests
-        response = requests.get(f"http://{PPS_HOST}:{PPS_PORT}/health", timeout=5)
+        token = _load_entity_token()
+        response = requests.get(
+            f"http://{PPS_HOST}:{PPS_PORT}/tools/summary_stats",
+            params={"token": token},
+            timeout=5,
+        )
         if response.status_code == 200:
-            health_data = response.json()
-            count = health_data.get("layers", {}).get("raw_capture", {}).get("unsummarized_count", 0)
+            stats = response.json()
+            count = stats.get("unsummarized_messages", 0)
             logger.info(f"Unsummarized count: {count}")
             return count
         else:
-            logger.error(f"PPS health check failed: {response.status_code}")
+            logger.error(f"PPS summary_stats failed: {response.status_code} {response.text[:200]}")
             return 0
     except Exception as e:
         logger.error(f"Failed to check unsummarized count: {e}")

--- a/tests/test_auto_summarize.py
+++ b/tests/test_auto_summarize.py
@@ -1,0 +1,64 @@
+"""
+Tests for check_unsummarized_count() in scripts/auto_summarize.py.
+
+Regression: the old implementation called GET /health which has no 'unsummarized_count'
+key, so stats.get("unsummarized_count", 0) always silently returned 0 — the threshold
+check never fired and summarization was never triggered.
+
+The fix reads from GET /tools/summary_stats?token=TOKEN which returns:
+    {"unsummarized_messages": N, "recent_summaries": N, ...}
+and the function now looks up stats.get("unsummarized_messages", 0).
+
+These tests run against live localhost:8201 — no mocking per project rule.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow importing from scripts/ without installing the package
+PROJECT_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.auto_summarize import check_unsummarized_count
+
+
+class TestCheckUnsummarizedCount:
+    """Tests for check_unsummarized_count() against the live PPS server."""
+
+    def test_returns_nonzero_count(self):
+        """
+        The fixed implementation reads from /tools/summary_stats and returns
+        the real unsummarized message count.
+
+        REGRESSION: the old code used GET /health, which has no
+        'unsummarized_count' key, so .get() silently returned 0 every time.
+        This asserts the bug is gone: the returned count must be > 0 because
+        we know unsummarized messages exist in the live database.
+        """
+        count = check_unsummarized_count()
+        assert count > 0, (
+            f"check_unsummarized_count() returned {count}. "
+            "A return of 0 is the regression symptom — the function may be "
+            "reading from GET /health instead of GET /tools/summary_stats."
+        )
+
+    def test_returns_int(self):
+        """Return value must be an int (not None, float, str, etc.)."""
+        count = check_unsummarized_count()
+        assert isinstance(count, int), (
+            f"Expected int, got {type(count).__name__}: {count!r}"
+        )
+
+    def test_idempotent_across_two_calls(self):
+        """
+        Calling the function twice in quick succession should return equal
+        values (no summarization happens between calls, so the count is stable).
+        """
+        count_a = check_unsummarized_count()
+        count_b = check_unsummarized_count()
+        assert count_a == count_b, (
+            f"First call returned {count_a}, second call returned {count_b}. "
+            "The count should be stable between back-to-back reads."
+        )


### PR DESCRIPTION
## Summary

Fixed silent failure in `auto_summarize.py` where the script was reading from the wrong endpoint. The `/health` endpoint no longer returns `unsummarized_count`, so the chained `.get()` always returned 0. Switched to `/tools/summary_stats?token=TOKEN` which returns the correct count.

This regression caused 800+ messages to be missed for summarization over ~38 hours.

## Changes

- `scripts/auto_summarize.py`: Replaced `check_unsummarized_count()` to call `/tools/summary_stats`
  - Added `_load_entity_token()` helper
  - Updated endpoint from `/health` to `/tools/summary_stats`
  - Changed key read from chained nested `.get()` to direct `unsummarized_messages` key
  - Improved error logging

- `tests/test_auto_summarize.py`: Added 3 regression tests
  - Asserts non-zero count (catches the regression)
  - Type validation (int)
  - Idempotent across calls (stability check)

## Test Plan

- [ ] Tests pass: `pytest tests/test_auto_summarize.py`
- [ ] Manual verification: Run `scripts/auto_summarize.py` with unsummarized messages; should trigger summarization
- [ ] Verify token loading works (ENTITY_PATH set correctly)

Closes #203