### PR TITLE
fix(haven): bridge self-sender skip — outbound messages missing from PPS

### DIFF
--- a/haven/bridge.py
+++ b/haven/bridge.py
@@ -49,9 +49,6 @@ async def bridge_message(
 
     tasks = []
     for entity_name, base_url in PPS_ENDPOINTS.items():
-        # Don't bridge a message TO the entity who sent it — they already know
-        if entity_name == username:
-            continue
         tasks.append(_send_to_pps(base_url, channel, content, display_name, entity_name))
 
     if tasks:

--- a/haven/test_bridge_self_sender.py
+++ b/haven/test_bridge_self_sender.py
@@ -1,0 +1,155 @@
+"""Unit test: bridge_message sends to ALL PPS endpoints including the sender's own.
+
+Regression test for the self-sender skip bug (GitHub issue filed with today's diagnosis).
+Before the fix, the sender's own PPS endpoint was skipped, causing outbound Haven messages
+to be missing from the sender's ambient_recall.
+
+Run:
+    python3 -m haven.test_bridge_self_sender
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _color(s: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return s
+    return f"\033[{code}m{s}\033[0m"
+
+
+GREEN = lambda s: _color(s, "32")
+RED = lambda s: _color(s, "31")
+
+
+class TestBridgeAllEndpoints(unittest.IsolatedAsyncioTestCase):
+    """bridge_message must POST to every PPS endpoint, including the sender's own."""
+
+    async def test_sender_endpoint_receives_message(self):
+        """The sending entity's own PPS endpoint must be called.
+
+        Regression: previously `if entity_name == username: continue` skipped this.
+        """
+        from haven import bridge
+
+        # Patch PPS_ENDPOINTS to have two entries: lyra and caia
+        fake_endpoints = {
+            "lyra": "http://pps-lyra:8000",
+            "caia": "http://pps-caia:8000",
+        }
+
+        called_urls: list[str] = []
+
+        async def fake_send(base_url: str, channel: str, content: str, author_name: str, entity_name: str) -> None:
+            called_urls.append(base_url)
+
+        with patch.dict(bridge.PPS_ENDPOINTS, fake_endpoints, clear=True), \
+             patch.object(bridge, "_send_to_pps", side_effect=fake_send):
+            # lyra sends a message — lyra's own endpoint must be called
+            await bridge.bridge_message(
+                room_name="dm-lyra-caia",
+                username="lyra",  # sender is lyra
+                display_name="Lyra",
+                content="Hey Caia, thoughts on the bridge fix?",
+                timestamp="2026-05-09T00:00:00Z",
+            )
+
+        self.assertIn(
+            "http://pps-lyra:8000",
+            called_urls,
+            "pps-lyra must receive lyra's own outbound message",
+        )
+        self.assertIn(
+            "http://pps-caia:8000",
+            called_urls,
+            "pps-caia must also receive the message",
+        )
+        self.assertEqual(
+            len(called_urls),
+            2,
+            f"Both endpoints must be called, got: {called_urls}",
+        )
+
+    async def test_both_endpoints_receive_when_caia_sends(self):
+        """Same guarantee when caia is the sender."""
+        from haven import bridge
+
+        fake_endpoints = {
+            "lyra": "http://pps-lyra:8000",
+            "caia": "http://pps-caia:8000",
+        }
+
+        called_entity_names: list[str] = []
+
+        async def fake_send(base_url: str, channel: str, content: str, author_name: str, entity_name: str) -> None:
+            called_entity_names.append(entity_name)
+
+        with patch.dict(bridge.PPS_ENDPOINTS, fake_endpoints, clear=True), \
+             patch.object(bridge, "_send_to_pps", side_effect=fake_send):
+            await bridge.bridge_message(
+                room_name="dm-lyra-caia",
+                username="caia",  # sender is caia
+                display_name="Caia",
+                content="Yes — the fix looks right to me.",
+                timestamp="2026-05-09T00:00:01Z",
+            )
+
+        self.assertIn("caia", called_entity_names, "caia endpoint must be called for caia's own message")
+        self.assertIn("lyra", called_entity_names, "lyra endpoint must receive caia's message")
+        self.assertEqual(len(called_entity_names), 2)
+
+    async def test_empty_endpoints_is_noop(self):
+        """If no PPS endpoints configured, bridge_message returns silently."""
+        from haven import bridge
+
+        with patch.dict(bridge.PPS_ENDPOINTS, {}, clear=True):
+            # Should not raise
+            await bridge.bridge_message(
+                room_name="general",
+                username="lyra",
+                display_name="Lyra",
+                content="hello",
+                timestamp="2026-05-09T00:00:02Z",
+            )
+
+
+def main() -> int:
+    loader = unittest.TestLoader()
+    suite = loader.loadTestsFromTestCase(TestBridgeAllEndpoints)
+
+    class VerboseResult(unittest.TextTestResult):
+        def addSuccess(self, test):
+            super().addSuccess(test)
+            print(f"  {GREEN('PASS')}  {test._testMethodName}")
+
+        def addFailure(self, test, err):
+            super().addFailure(test, err)
+            print(f"  {RED('FAIL')}  {test._testMethodName}")
+            print(f"        {err[1]}")
+
+        def addError(self, test, err):
+            super().addError(test, err)
+            print(f"  {RED('ERR ')}  {test._testMethodName}")
+            print(f"        {err[1]}")
+
+    print(f"\n=== Bridge self-sender regression tests ===\n")
+    runner = unittest.TextTestRunner(
+        stream=open("/dev/null", "w"),
+        resultclass=VerboseResult,
+        verbosity=0,
+    )
+    result = runner.run(suite)
+
+    total = result.testsRun
+    passed = total - len(result.failures) - len(result.errors)
+    print(f"\n  Results: {passed}/{total} pass")
+
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Removes 3-line guard in `haven/bridge.py` that skipped writing to the sender's own PPS endpoint
- Outbound Haven messages from Lyra/Caia now land in both PPS databases (sender + recipient)
- Adds regression test `haven/test_bridge_self_sender.py` (3 cases, all pass)

Closes #206.

## What was broken

When Lyra sent a message in `dm-lyra-caia`, the bridge wrote it to `pps-caia` but NOT `pps-lyra`. Terminal-Lyra's `ambient_recall` could not surface her own Haven outbound messages. Same on the Caia side. The bug was latent since bridge introduction; became observable after PR #200 stabilized Haven/PPS sync.

## Why the fix is safe

`pps/docker/server_http.py` `poll_haven()` already filters `username == ENTITY_NAME` (lines 479-481) to prevent double-notification on the display side. The bridge-side skip was doing duplicate work incorrectly — skipping DB writes rather than display suppression.

## Test plan

- [x] `python3 -m py_compile haven/bridge.py` — syntax OK
- [x] `pps/venv/bin/python3 -m haven.test_bridge_self_sender` — 3/3 pass
  - `test_sender_endpoint_receives_message` — lyra's own PPS gets her outbound
  - `test_both_endpoints_receive_when_caia_sends` — same guarantee for caia
  - `test_empty_endpoints_is_noop` — no crash when no endpoints configured

## Zero file overlap with Caia's concurrent work

This PR touches only `haven/bridge.py` and `haven/test_bridge_self_sender.py`.
Caia's concurrent branch (`caia/update-space-tool`) touches `pps/server.py` and `pps/layers/inventory.py` — no conflict.

## Deploy note

After merge, restart Haven containers:

```bash
systemctl --user restart lyra-haven caia-haven haven-flow-observer
```

Or rebuild the Haven image if deployed via Docker Compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)