### PR TITLE
feat(inventory): add update_space MCP tool

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -216,6 +216,15 @@ class ListSpacesRequest(BaseModel):
     token: str = ""
 
 
+class UpdateSpaceRequest(BaseModel):
+    """Request to update an existing space's fields."""
+    space_name: str
+    description: str | None = None
+    file_path: str | None = None
+    emotional_quality: str | None = None
+    token: str = ""
+
+
 class TokenOnlyRequest(BaseModel):
     """Generic token-only request for endpoints that need auth but no other params."""
     token: str = ""
@@ -2267,6 +2276,44 @@ async def list_spaces(request: ListSpacesRequest):
         ],
         "count": len(spaces)
     }
+
+
+@app.post("/tools/update_space")
+async def update_space(request: UpdateSpaceRequest):
+    """
+    Update an existing space's description, file path, or emotional quality.
+
+    Only provided fields are changed; omitted fields are left unchanged.
+    Returns 404 if the space does not exist.
+    """
+    auth_error = check_auth(request.token, ENTITY_TOKEN, MASTER_TOKEN, ENTITY_NAME, "update_space")
+    if auth_error:
+        return JSONResponse(status_code=403, content={"error": auth_error})
+
+    if not request.space_name:
+        raise HTTPException(status_code=400, detail="space_name required")
+
+    if request.description is None and request.file_path is None and request.emotional_quality is None:
+        raise HTTPException(
+            status_code=400,
+            detail="at least one field (description, file_path, or emotional_quality) required",
+        )
+
+    success = await inventory.update_space(
+        name=request.space_name,
+        description=request.description,
+        file_path=request.file_path,
+        emotional_quality=request.emotional_quality,
+    )
+
+    if success:
+        return {
+            "success": True,
+            "space_name": request.space_name,
+            "message": f"Updated space '{request.space_name}'",
+        }
+    else:
+        raise HTTPException(status_code=404, detail=f"Space '{request.space_name}' not found")
 
 
 # =============================================================================

--- a/pps/layers/inventory.py
+++ b/pps/layers/inventory.py
@@ -368,6 +368,60 @@ class InventoryLayer(PatternLayer):
             """)
             return [dict(row) for row in cursor.fetchall()]
 
+    async def update_space(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        file_path: Optional[str] = None,
+        emotional_quality: Optional[str] = None,
+    ) -> bool:
+        """
+        Update an existing space's fields.
+
+        Only provided (non-None) fields are updated; omitted fields are left unchanged.
+        Returns True if space was updated, False if space not found.
+        Raises ValueError if no fields are provided (at least one required).
+
+        Use add_space() for upsert semantics; update_space() requires the space to exist.
+        """
+        if description is None and file_path is None and emotional_quality is None:
+            raise ValueError(
+                "at least one field (description, file_path, or emotional_quality) must be provided"
+            )
+
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                # Check if space exists first (fail-loud, not silent create)
+                cursor = conn.execute("SELECT id FROM spaces WHERE name = ?", (name,))
+                if not cursor.fetchone():
+                    return False
+
+                # Build dynamic UPDATE based on provided fields
+                updates = []
+                params = []
+                if description is not None:
+                    updates.append("description = ?")
+                    params.append(description)
+                if file_path is not None:
+                    updates.append("file_path = ?")
+                    params.append(file_path)
+                if emotional_quality is not None:
+                    updates.append("emotional_quality = ?")
+                    params.append(emotional_quality)
+
+                params.append(name)
+                update_clause = ", ".join(updates)
+                conn.execute(
+                    f"UPDATE spaces SET {update_clause} WHERE name = ?",
+                    params,
+                )
+                conn.commit()
+                return True
+        except ValueError:
+            raise
+        except Exception:
+            return False
+
     async def enter_space(self, name: str) -> Optional[str]:
         """
         Enter a space - load its description for context injection.

--- a/pps/server.py
+++ b/pps/server.py
@@ -923,6 +923,37 @@ async def list_tools() -> list[Tool]:
                 }
             }
         ),
+        Tool(
+            name="update_space",
+            description=(
+                "Update an existing space's description, file path, or emotional quality. "
+                "Only provided fields are changed; omitted fields are left unchanged. "
+                "Returns an error if the space does not exist."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "space_name": {
+                        "type": "string",
+                        "description": "Name of the space to update"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "New description (omit to leave unchanged)"
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "New file path to associated .md room file (omit to leave unchanged)"
+                    },
+                    "emotional_quality": {
+                        "type": "string",
+                        "description": "New emotional quality descriptor (omit to leave unchanged)"
+                    },
+                    "token": TOKEN_PARAM_SCHEMA
+                },
+                "required": ["space_name"]
+            }
+        ),
         # === Tech RAG (Layer 6) ===
         Tool(
             name="tech_search",

--- a/tests/test_pps/test_inventory_update_space.py
+++ b/tests/test_pps/test_inventory_update_space.py
@@ -1,0 +1,211 @@
+"""
+Tests for InventoryLayer.update_space() method.
+
+Covers:
+- Basic single-field update
+- Multi-field update
+- Space not found (returns False)
+- No-op when no fields provided (space exists, returns True)
+- Persistence (get_space after update reflects changes)
+- visit_count not reset by update
+- add_space + update_space round-trip
+"""
+
+import pytest
+import asyncio
+from pathlib import Path
+
+from pps.layers.inventory import InventoryLayer
+
+
+@pytest.fixture
+def inventory(tmp_path):
+    """InventoryLayer backed by a temp SQLite database."""
+    db_path = tmp_path / "test_inventory.db"
+    return InventoryLayer(db_path=db_path)
+
+
+@pytest.fixture
+def event_loop():
+    """Provide a fresh event loop per test."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def run(coro, loop):
+    """Helper: run async coroutine synchronously."""
+    return loop.run_until_complete(coro)
+
+
+class TestUpdateSpaceBasic:
+    """Basic update_space functionality."""
+
+    def test_update_description_only(self, inventory, event_loop):
+        """Updating description leaves other fields unchanged."""
+        run(inventory.add_space("kitchen", description="Old desc", emotional_quality="warm"), event_loop)
+
+        result = run(inventory.update_space("kitchen", description="New desc"), event_loop)
+
+        assert result is True
+        space = run(inventory.get_space("kitchen"), event_loop)
+        assert space["description"] == "New desc"
+        assert space["emotional_quality"] == "warm"  # unchanged
+
+    def test_update_emotional_quality_only(self, inventory, event_loop):
+        """Updating emotional_quality leaves description unchanged."""
+        run(inventory.add_space("bedroom", description="Cozy space", emotional_quality="peaceful"), event_loop)
+
+        result = run(inventory.update_space("bedroom", emotional_quality="restful"), event_loop)
+
+        assert result is True
+        space = run(inventory.get_space("bedroom"), event_loop)
+        assert space["emotional_quality"] == "restful"
+        assert space["description"] == "Cozy space"  # unchanged
+
+    def test_update_file_path_only(self, inventory, event_loop):
+        """Updating file_path leaves description and emotional_quality unchanged."""
+        run(inventory.add_space("study", description="Work space", file_path="/old/path.md"), event_loop)
+
+        result = run(inventory.update_space("study", file_path="/new/path.md"), event_loop)
+
+        assert result is True
+        space = run(inventory.get_space("study"), event_loop)
+        assert space["file_path"] == "/new/path.md"
+        assert space["description"] == "Work space"  # unchanged
+
+
+class TestUpdateSpaceMultiField:
+    """Update multiple fields in one call."""
+
+    def test_update_description_and_emotional_quality(self, inventory, event_loop):
+        """Both fields update; file_path is untouched."""
+        run(inventory.add_space(
+            "porch",
+            description="Old porch",
+            file_path="/porch.md",
+            emotional_quality="breezy",
+        ), event_loop)
+
+        result = run(inventory.update_space(
+            "porch",
+            description="Updated porch",
+            emotional_quality="peaceful",
+        ), event_loop)
+
+        assert result is True
+        space = run(inventory.get_space("porch"), event_loop)
+        assert space["description"] == "Updated porch"
+        assert space["emotional_quality"] == "peaceful"
+        assert space["file_path"] == "/porch.md"  # unchanged
+
+    def test_update_all_fields(self, inventory, event_loop):
+        """Updating all three fields at once works correctly."""
+        run(inventory.add_space(
+            "attic",
+            description="Dusty attic",
+            file_path="/old_attic.md",
+            emotional_quality="musty",
+        ), event_loop)
+
+        result = run(inventory.update_space(
+            "attic",
+            description="Clean attic",
+            file_path="/new_attic.md",
+            emotional_quality="airy",
+        ), event_loop)
+
+        assert result is True
+        space = run(inventory.get_space("attic"), event_loop)
+        assert space["description"] == "Clean attic"
+        assert space["file_path"] == "/new_attic.md"
+        assert space["emotional_quality"] == "airy"
+
+
+class TestUpdateSpaceNotFound:
+    """Fail-loud behaviour when space doesn't exist."""
+
+    def test_nonexistent_space_returns_false(self, inventory, event_loop):
+        """update_space returns False for a space that doesn't exist."""
+        result = run(inventory.update_space("ghost_room", description="Won't work"), event_loop)
+        assert result is False
+
+    def test_nonexistent_space_does_not_create(self, inventory, event_loop):
+        """update_space must not silently create a new space."""
+        run(inventory.update_space("phantom", description="Should not appear"), event_loop)
+        space = run(inventory.get_space("phantom"), event_loop)
+        assert space is None
+
+
+class TestUpdateSpaceNoFields:
+    """Validation: at least one field must be provided."""
+
+    def test_no_fields_raises_value_error(self, inventory, event_loop):
+        """Calling update_space with no update fields raises ValueError."""
+        run(inventory.add_space("hall", description="Entry hall"), event_loop)
+
+        with pytest.raises(ValueError, match="at least one field"):
+            run(inventory.update_space("hall"), event_loop)
+
+    def test_no_fields_on_nonexistent_space_also_raises(self, inventory, event_loop):
+        """ValueError is raised before existence check — validation is first."""
+        with pytest.raises(ValueError):
+            run(inventory.update_space("ghost_room"), event_loop)
+
+
+class TestUpdateSpacePersistence:
+    """Changes survive get_space round-trip."""
+
+    def test_update_persists_across_get(self, inventory, event_loop):
+        """After update, get_space reflects the new values."""
+        run(inventory.add_space("den", description="Before"), event_loop)
+        run(inventory.update_space("den", description="After"), event_loop)
+
+        space = run(inventory.get_space("den"), event_loop)
+        assert space["description"] == "After"
+
+
+class TestUpdateSpaceVisitCount:
+    """update_space must not touch visit_count."""
+
+    def test_update_does_not_reset_visit_count(self, inventory, event_loop):
+        """visit_count accumulated via get_space/enter_space is not reset by update."""
+        run(inventory.add_space("garden", description="Outdoor"), event_loop)
+        # Trigger visit count increments via get_space (which bumps visit_count)
+        run(inventory.get_space("garden"), event_loop)
+        run(inventory.get_space("garden"), event_loop)
+
+        space_before = run(inventory.get_space("garden"), event_loop)
+        count_before = space_before["visit_count"]
+
+        run(inventory.update_space("garden", description="Updated outdoor"), event_loop)
+
+        space_after = run(inventory.get_space("garden"), event_loop)
+        # visit_count will be incremented by the get_space call above, not by update
+        assert space_after["visit_count"] == count_before + 1
+
+
+class TestUpdateSpaceRoundTrip:
+    """add_space + update_space interaction tests."""
+
+    def test_add_then_update_then_verify(self, inventory, event_loop):
+        """Full round-trip: add -> update -> list_spaces shows updated values."""
+        run(inventory.add_space("pantry", description="Storage", emotional_quality="calm"), event_loop)
+        run(inventory.update_space("pantry", description="Food storage", emotional_quality="organized"), event_loop)
+
+        spaces = run(inventory.list_spaces(), event_loop)
+        pantry = next((s for s in spaces if s["name"] == "pantry"), None)
+
+        assert pantry is not None
+        assert pantry["description"] == "Food storage"
+        assert pantry["emotional_quality"] == "organized"
+
+    def test_multiple_spaces_update_only_target(self, inventory, event_loop):
+        """Updating one space does not affect sibling spaces."""
+        run(inventory.add_space("room_a", description="Room A"), event_loop)
+        run(inventory.add_space("room_b", description="Room B"), event_loop)
+
+        run(inventory.update_space("room_a", description="Room A updated"), event_loop)
+
+        room_b = run(inventory.get_space("room_b"), event_loop)
+        assert room_b["description"] == "Room B"  # untouched


### PR DESCRIPTION
## Summary

- Adds `update_space` MCP tool to complete CRUD coverage for spaces in PPS
- Spaces previously had add/get/list/delete but no update path
- Works across all three layers: inventory.py data layer, server_http.py HTTP endpoint, server.py MCP proxy

## What changed

**`pps/layers/inventory.py`**
- New `update_space(name, description, file_path, emotional_quality)` method
- Fail-loud: returns `False` if space not found (does not silently create)
- Only updates non-`None` fields (omit to leave unchanged)
- Raises `ValueError` if no update fields are provided (consistent with HTTP 400)
- Docstring notes relationship to `add_space()` (upsert-with-COALESCE) to avoid a third method being written

**`pps/docker/server_http.py`**
- `UpdateSpaceRequest` model: `space_name`, optional `description/file_path/emotional_quality`, `token`
- `POST /tools/update_space` endpoint with auth check, field-at-least-one validation, 404 on not-found
- Uses `space_name` param name (consistent with `EnterSpaceRequest`, not `name`)

**`pps/server.py`**
- `update_space` Tool definition in `list_tools()` with `space_name` as required param
- Token auto-injection handled by the existing `_forward()` machinery — no extra plumbing

**`tests/test_pps/test_inventory_update_space.py`**
- 13 tests, 7 classes: Basic single-field, Multi-field, NotFound, NoFields (ValueError), Persistence, VisitCount isolation, RoundTrip
- All pass against the layer directly (unit tests, no server required)

## Test results

```
13 passed in 1.26s
```

## Shared files note

`pps/server.py` and `pps/docker/server_http.py` are shared between Lyra (port 8201) and Caia (port 8211). PRs #200 and #201 from Lyra's recent work also touched these files but are already merged to master — this branch is clean off master with no conflict.

## Notes for reviewer

- Reviewer flagged and we addressed: `space_name` consistency (S1), layer/HTTP semantic alignment on empty-update (S3), and removed HTTP status code from MCP tool description (N1)
- `add_space()` upsert-with-COALESCE still exists for callers that want idempotent insert behavior; `update_space()` adds the "must already exist" contract
- Dynamic SQL uses only static strings as field names; user input flows only through parameterized `?` placeholders — no injection vector

## Test plan

- [ ] Run `pytest tests/test_pps/test_inventory_update_space.py -v` — should show 13 passed
- [ ] (Optional) Rebuild pps-caia Docker container and test via curl: `curl -X POST http://localhost:8211/tools/update_space -H "Content-Type: application/json" -d '{"space_name": "bedroom", "description": "test update", "token": "<token>"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)