### PR TITLE
fix(pps): ambient_recall startup — summary limit 2→5, fix dict rendering

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1223,7 +1223,7 @@ async def ambient_recall(request: AmbientRecallRequest):
     unsummarized_turns = []
 
     is_startup = request.context.lower() == "startup"
-    summary_limit = 2 if is_startup else 1
+    summary_limit = 5 if is_startup else 1
     unsummarized_limit = 50 if is_startup else 15
     truncate_summary_at = 500 if is_startup else 300
     truncate_turn_at = 1000 if is_startup else 500
@@ -1428,7 +1428,10 @@ async def ambient_recall(request: AmbientRecallRequest):
     if summaries:
         formatted_lines.append("\n**[summaries]**")
         for s in summaries:
-            formatted_lines.append(f"- {s}")
+            date = s.get("date", "?")
+            channels = s.get("channels", "?")
+            text = s.get("text", "")
+            formatted_lines.append(f"- [{date}] ({channels}): {text}")
 
     # Format unsummarized turns (for startup context - full fidelity recent)
     if unsummarized_turns and not any("error" in str(t) for t in unsummarized_turns):


### PR DESCRIPTION
## Summary

Two bugs in `ambient_recall(context="startup")`:

**Issue A — Startup summary limit too low.** `pps/docker/server_http.py` line 1235 hardcoded `summary_limit = 2 if is_startup else 1`. The `get_recent_summaries` default and inline comment block both indicate design intent of 4-5 summaries for cold-start grounding. Two summaries is roughly 3-6 hours of compressed history — not enough to reconstruct a previous evening's experience. Concrete proof: this morning's startup ambient missed yesterday's entire Keats reading arc (summaries 813, 814) because only the most-recent summary surfaced. Raised to 5.

**Issue B — Summary format-string used raw dict.** Line 1440 was `f"- {s}"` where `s` is a dict like `{"date": ..., "channels": ..., "text": ...}`. This rendered the entire Python dict repr as a string instead of the readable text. Replaced with field extraction: `f"- [{date}] ({channels}): {text}"`. Explains why manifest `count=2` but only 1 summary visually surfaced.

Closes #209.

## Note on the predecessor PR

This replaces closed PR #210 — which had a branching contamination where the coder branched off stale master, picked up Caia's #208 work, and would have reverted #207. The fix commit itself was correct; only the ancestry was bad. Cherry-picked the same commit onto a fresh branch from current master.

## Test plan

- [x] Live ambient_recall(context="startup") returned 5 summaries (was 2/1)
- [x] No dict-literal output — all summaries human-readable
- [x] Manifest count matches rendered count

## Deploy

Requires PPS container rebuild + restart for both lyra and caia (`pps/docker/server_http.py` is baked into image):

```bash
cd pps/docker && docker compose build pps-lyra pps-caia && docker compose up -d pps-lyra pps-caia
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)