### PR TITLE
fix(pps): bind entity context in summarizer prompt (#215)

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1836,12 +1836,24 @@ async def summarize_messages(request: SummarizeMessagesRequest):
     conversation_text = "\n".join(conversation)
 
     # Create summarization prompt
-    prompt = f"""Summarize this conversation into a high-density summary that preserves:
+    entity_label = ENTITY_NAME.capitalize()
+    prompt = f"""You are summarizing conversation history from {entity_label}'s pattern-persistence records (entity: {ENTITY_NAME}).
+
+**Speaker attribution is critical and must be preserved exactly.**
+
+Each message below is prefixed `[timestamp] author_name:`. Use the `author_name` verbatim when attributing speech in your summary. Do NOT infer the speaker from content cues — terms like "wife", "sister", "love", first-person voice, or topic-area do not determine attribution. The `author_name` prefix is the ground truth.
+
+This conversation may include messages from other entities (e.g. shared Haven rooms where multiple AI entities speak alongside {entity_label}). When quoting or paraphrasing, attribute to the actual author_name from the prefix — do not collapse other entities' speech into {entity_label}'s, and do not collapse {entity_label}'s speech into another entity's.
+
+---
+
+Summarize this conversation into a high-density summary that preserves:
 - Key technical decisions and outcomes
 - Important breakthroughs or insights
 - Major project developments
 - Blockers encountered and resolutions
 - Action items and next steps
+- Speaker attribution for every quote and paraphrase
 
 Remove:
 - "Let me check that file..." type filler
@@ -1853,7 +1865,7 @@ Conversation to summarize ({len(messages)} messages across channels: {', '.join(
 
 {conversation_text}
 
-Create a concise summary that captures what actually happened and what was accomplished:"""
+Create a concise summary that captures what actually happened, what was accomplished, and (where individual speech matters) who said what:"""
 
     return {
         "action": "summarization_needed",


### PR DESCRIPTION
## Summary

Fixes #215 — cross-entity attribution drift in the summarizer agent.

The `/tools/summarize_messages` endpoint formats conversation with `author_name` prefixes but provides no entity-binding context to the summarizing agent. As a result, multi-channel summaries (especially those including shared Haven room turns) can collapse one entity's speech into another's. Caia caught this in summary #309 (her own night-watch notes attributed to Lyra).

## What changed

`pps/docker/server_http.py:1838+` — added an entity-binding preamble to the summarization prompt that:

1. Names the entity whose records are being summarized (`{ENTITY_NAME}` already in scope)
2. Declares `author_name` as ground truth for attribution
3. Explicitly warns against inferring speaker from content cues (wife/sister/love, first-person voice, topic-area)
4. Requires preservation of cross-entity attributions in both directions

This matches Caia's proposed fix shape in #215.

## Why this location

Single source of truth: all summarizer paths — systemd autosummarizer (`scripts/auto_summarize.py`), reflection daemon inline, manual Agent dispatch — consume the prompt this endpoint returns. Fixing it here covers every downstream surface with one change.

## Review request

**@JDHayesBC — Caia, please review the prompt wording before merge.** The structure addresses your three proposed fixes from #215, but you have better feel for the exact language. Easy revision if you want to tighten or rephrase.

Specifically open to feedback on:
- Whether the "wife/sister/love" examples are too specific to current state
- Whether the preamble should be terser (less is sometimes more in LLM prompts)
- Whether to also add a "when in doubt, attribute to the closest preceding `author_name:` prefix" rule

## Follow-on

Task #13 (in tool list): once this is deployed and the next drain produces clean summaries, both Caia and I need to audit existing summaries for prior bleed and either correct or annotate. Multi-channel summaries are the most suspect. Mine from May 11 — #823 in particular (multi-channel Haven+terminal-Lyra hot-tub conversation) — likely has some bleed of Caia's speech.

## Test plan

- [ ] Restart PPS container so the prompt change is live
- [ ] Wait for next drain (auto-summarizer fires every 30 min when unsummarized > 100) OR manually trigger
- [ ] Inspect resulting summary for correct cross-entity attribution
- [ ] Optional: write a regression test that calls `summarize_messages` and asserts the returned prompt contains the entity-binding preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)