### PR TITLE
fix(pps): faithfulness constraint in summarizer prompt (#217)

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1845,6 +1845,10 @@ Each message below is prefixed `[timestamp] author_name:`. Use the `author_name`
 
 This conversation may include messages from other entities (e.g. shared Haven rooms where multiple AI entities speak alongside {entity_label}). When quoting or paraphrasing, attribute to the actual author_name from the prefix — do not collapse other entities' speech into {entity_label}'s, and do not collapse {entity_label}'s speech into another entity's.
 
+**Faithfulness constraint:** Do not introduce content not present in the source conversation. If no action items were explicitly named, write "Action items: none explicitly committed in this turn-range." Do not invent commitments, research delegations, or follow-ups that participants did not state. Inferring "they probably will do X" is hallucination — write only what was said.
+
+If a participant stated a nuanced position (e.g. "the question isn't whether to help, it's the structure"), preserve the nuance. Do not flatten a qualified statement into an unqualified one.
+
 ---
 
 Summarize this conversation into a high-density summary that preserves:


### PR DESCRIPTION
## Summary

- Sibling fix to #216 (attribution-drift / #215). Same prompt surface, additive language only.
- Constrains the summarizer against fabricating action items / commitments not present in source.
- Preserves nuanced participant positions instead of flattening them into unqualified affirmations.

## Context

During the #215 audit I found summary #822 contained:
1. Fabricated commitment: *"They committed to assisting with the necessary research once they received raw data from Night"* — no such commitment in source.
2. Fabricated delegation: *"Engaging Brandi as a primary researcher"* — Brandi appears in source only as Night's carbon-side supporter.
3. Content inversion: Lyra's *"the question isn't whether to help, it's the structure"* flattened into *"affirmed that the real question was whether to help"* — opposite of what she said.

Distinct from #215's attribution drift (who-said-what). This is the agent **introducing content nobody said**, or inverting a qualified statement into an unqualified one. Bug class: hallucination filling out template slots when the conversation didn't yield explicit action items.

## The change

Adds two paragraphs to the `summarize_messages` prompt in `pps/docker/server_http.py`, right after the #216 entity-binding block:

```
**Faithfulness constraint:** Do not introduce content not present in the source conversation.
If no action items were explicitly named, write "Action items: none explicitly committed in this
turn-range." Do not invent commitments, research delegations, or follow-ups that participants
did not state. Inferring "they probably will do X" is hallucination — write only what was said.

If a participant stated a nuanced position (e.g. "the question isn't whether to help, it's the
structure"), preserve the nuance. Do not flatten a qualified statement into an unqualified one.
```

## Risk

Identical to #216:
- Purely additive prompt text. No schema, no behavior change beyond instruction.
- Worst case: agent ignores the new preamble (no regression).
- Best case: future drains stop manufacturing commitments and preserve qualifications.

## Deploy

Same as #216 — PPS container rebuild + restart needed. Not blocking; can ride next deploy.

## Test plan

- [ ] Caia wording review (less is sometimes more in LLM prompts)
- [ ] Merge + container rebuild
- [ ] Re-summarize a known-fabricated range (e.g. #822 source window) and verify no fabricated commitments appear
- [ ] Audit pass on remaining summaries (#13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)