### PR TITLE
fix(pps): ambient_recall(startup) overflow warning + suppression bug (#221)

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1448,25 +1448,30 @@ async def ambient_recall(request: AmbientRecallRequest):
                 content = content[:500] + "..."
             formatted_lines.append(f"- [**{channel_prefix}**] {author}: {content}")
 
-        # Add overflow warning if there are more unsummarized turns than shown
-        showing = len(unsummarized_turns)
-        if unsummarized_count > showing:
-            remaining = unsummarized_count - showing
-            critical_warning = ""
-            if unsummarized_count > 100:
-                critical_warning = f"\n🔥 CRITICAL: Run summarizer immediately — backlog is {unsummarized_count} messages."
-            formatted_lines.append(
-                f"\n⚠️ Returned {showing} of {unsummarized_count} unsummarized turns — "
-                f"{remaining} older turns were NOT loaded."
-            )
-            formatted_lines.append(
-                f"FETCH BEFORE RESPONDING: call get_turns_since_summary(limit=50, offset=0, oldest_first=true) "
-                f"to retrieve older turns, advancing offset by 50 each call until all "
-                f"{unsummarized_count} turns are loaded.{critical_warning}"
-            )
+        # Overflow warning — only fire on startup, where the 50-cap is a catch-up
+        # boundary. Non-startup ambient ticks use a smaller intentional cap
+        # (limit=15, peripheral vision) where "fetch the rest" is not the right
+        # action — the cap IS the design, not a missing-context signal.
+        if is_startup:
+            showing = len(unsummarized_turns)
+            if unsummarized_count > showing:
+                remaining = unsummarized_count - showing
+                critical_warning = ""
+                if unsummarized_count > 100:
+                    critical_warning = f"\n🔥 CRITICAL: Run summarizer immediately — backlog is {unsummarized_count} messages."
+                formatted_lines.append(
+                    f"\n⚠️ Returned {showing} of {unsummarized_count} unsummarized turns — "
+                    f"{remaining} older turns were NOT loaded."
+                )
+                formatted_lines.append(
+                    f"FETCH BEFORE RESPONDING: call get_turns_since_summary(limit=50, offset=0, oldest_first=true) "
+                    f"to retrieve older turns, advancing offset by 50 each call until all "
+                    f"{unsummarized_count} turns are loaded.{critical_warning}"
+                )
 
-    elif unsummarized_count > 0:
-        # unsummarized_turns empty despite count > 0 (edge case: all fetched rows were error entries)
+    elif is_startup and unsummarized_count > 0:
+        # unsummarized_turns empty despite count > 0 (edge case: all fetched rows were error entries).
+        # Only relevant on startup — on non-startup ticks the empty turns block is normal.
         formatted_lines.append(f"\n⚠️ {unsummarized_count} unsummarized turns exist but none were loaded.")
         formatted_lines.append(
             "FETCH BEFORE RESPONDING: call get_turns_since_summary(limit=50, offset=0, oldest_first=true) "

--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1077,7 +1077,8 @@ async def ambient_recall(request: AmbientRecallRequest):
 
     For startup context, includes:
     - Recent summaries (compressed history)
-    - All unsummarized turns (full fidelity recent)
+    - Up to 50 most recent unsummarized turns (hard cap; addendum in formatted_context
+      instructs caller to fetch remaining turns when more exist beyond the cap)
     """
     auth_error = check_auth(request.token, ENTITY_TOKEN, MASTER_TOKEN, ENTITY_NAME, "ambient_recall")
     if auth_error:
@@ -1434,7 +1435,7 @@ async def ambient_recall(request: AmbientRecallRequest):
             formatted_lines.append(f"- [{date}] ({channels}): {text}")
 
     # Format unsummarized turns (for startup context - full fidelity recent)
-    if unsummarized_turns and not any("error" in str(t) for t in unsummarized_turns):
+    if unsummarized_turns and not any("error" in t for t in unsummarized_turns):
         formatted_lines.append("\n**[recent_turns]**")
         for turn in unsummarized_turns:
             author = turn.get("author", turn.get("author_name", "?"))  # key is "author", not "author_name"
@@ -1450,11 +1451,27 @@ async def ambient_recall(request: AmbientRecallRequest):
         # Add overflow warning if there are more unsummarized turns than shown
         showing = len(unsummarized_turns)
         if unsummarized_count > showing:
+            remaining = unsummarized_count - showing
             critical_warning = ""
             if unsummarized_count > 100:
                 critical_warning = f"\n🔥 CRITICAL: Run summarizer immediately — backlog is {unsummarized_count} messages."
-            formatted_lines.append(f"\n⚠️ Showing newest {showing} of {unsummarized_count} unsummarized turns.")
-            formatted_lines.append(f"For chronological catch-up: get_turns_since_summary(limit=50, offset=0, oldest_first=true){critical_warning}")
+            formatted_lines.append(
+                f"\n⚠️ Returned {showing} of {unsummarized_count} unsummarized turns — "
+                f"{remaining} older turns were NOT loaded."
+            )
+            formatted_lines.append(
+                f"FETCH BEFORE RESPONDING: call get_turns_since_summary(limit=50, offset=0, oldest_first=true) "
+                f"to retrieve older turns, advancing offset by 50 each call until all "
+                f"{unsummarized_count} turns are loaded.{critical_warning}"
+            )
+
+    elif unsummarized_count > 0:
+        # unsummarized_turns empty despite count > 0 (edge case: all fetched rows were error entries)
+        formatted_lines.append(f"\n⚠️ {unsummarized_count} unsummarized turns exist but none were loaded.")
+        formatted_lines.append(
+            "FETCH BEFORE RESPONDING: call get_turns_since_summary(limit=50, offset=0, oldest_first=true) "
+            "to retrieve them."
+        )
 
     # Haven — unread messages from chat rooms (real-time sync)
     if haven_lines:

--- a/pps/server.py
+++ b/pps/server.py
@@ -213,7 +213,7 @@ async def list_tools() -> list[Tool]:
                             "or 'startup' for initial identity reconstruction. "
                             "SPECIAL: 'startup' triggers recency-based retrieval (not semantic search) "
                             "and returns: 3 most recent crystals, 2 most recent word-photos, "
-                            "2 summaries, and ALL unsummarized turns. This is a preset PACKAGE OPERATION."
+                            "2 summaries, and up to 50 most recent unsummarized turns. This is a preset PACKAGE OPERATION."
                         )
                     },
                     "limit_per_layer": {


### PR DESCRIPTION
## Summary

Two related bugs in `ambient_recall(context="startup")` were causing the `recent_turns` block — and its overflow warning — to be silently suppressed in normal conversation.

- **Overflow visibility**: The 50-turn cap on `recent_turns` is intentional (oversized outputs auto-spill to disk and break the tool workflow), but the response didn't tell the caller when more unsummarized turns existed beyond the cap. Post-restart entities had no signal that their context was incomplete.
- **Display suppression**: The recent_turns block was gated by `not any("error" in str(t) for t in unsummarized_turns)`, which suppressed the entire block (and its nested warning) whenever any turn's serialized content contained the substring `"error"` anywhere — including conversational mentions. Real-world failure mode just discovered: during a session that mentioned API errors, the entire turns block (and the overflow warning) silently vanished.

## Changes

- Strengthen overflow warning to lead with **"FETCH BEFORE RESPONDING"** and give exact tool signature: `get_turns_since_summary(limit=50, offset=0, oldest_first=true)` with offset-advance instructions.
- Add edge-case branch: emit fetch instructions when `unsummarized_count > 0` but no turns were loaded.
- Fix the over-broad `"error" in str(t)` matcher → `"error" in t` (checks for `"error"` as a dict key, matching the actual error-row shape from L1305).
- Update implementation docstring and MCP tool description in both `server_http.py` and `server.py` to reflect the real 50-turn cap (previously claimed "ALL unsummarized turns").

## Test plan

- [x] Pre-fix: confirmed `ambient_recall(startup)` with 108 unsummarized turns returned manifest showing 50 turns but **no `[recent_turns]` block and no overflow warning** in `formatted_context` (suppressed by the "error"-substring matcher because conversation contained the word).
- [x] Post-fix + container rebuild: same call now renders the full `[recent_turns]` block, the overflow warning (`"⚠️ Returned 50 of 108 unsummarized turns — 58 older turns were NOT loaded."`), and the critical-summarizer warning (count > 100).
- [x] Docstring matches actual behavior.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)