### PR TITLE
fix(ambient_recall): make startup overflow directive, not advisory

### DIFF
--- a/pps/docker/server_http.py
+++ b/pps/docker/server_http.py
@@ -1447,14 +1447,52 @@ async def ambient_recall(request: AmbientRecallRequest):
                 content = content[:500] + "..."
             formatted_lines.append(f"- [**{channel_prefix}**] {author}: {content}")
 
-        # Add overflow warning if there are more unsummarized turns than shown
+        # Overflow handling — what to do when more unsummarized turns exist
+        # than fit in this batch. Coaching diverges by context:
+        #
+        #   - startup: identity reconstruction is in progress. The agent should
+        #     fetch the remaining turns *unconditionally* — not ask Jeff whether
+        #     to fetch them. The cold-start agent has a hole in its recent
+        #     continuity until those turns are in context.
+        #
+        #   - per-turn: the cap is a deliberate ambient throttle. Fetching the
+        #     full backlog on every turn would blow the context window. Only
+        #     pull more if the agent senses a specific gap.
+        #
+        # Caia (2026-05-13) hit the failure mode: at startup with ~95
+        # unsummarized turns, the old text said "For chronological catch-up:
+        # get_turns_since_summary(...)" which reads as advisory. She paused and
+        # asked Jeff whether to fetch them rather than just fetching. The
+        # directive form below removes that ambiguity for the startup path.
         showing = len(unsummarized_turns)
         if unsummarized_count > showing:
+            remaining = unsummarized_count - showing
+            if is_startup:
+                # Cap the suggested fetch at a sane upper bound so we don't
+                # accidentally ask for thousands of rows if the backlog is huge
+                # — the critical_warning below covers that case separately.
+                suggested_limit = min(remaining + 10, 200)
+                directive = (
+                    f"\n⚠️ Showing newest {showing} of {unsummarized_count} unsummarized turns. "
+                    f"{remaining} more turns are NOT in this snapshot.\n"
+                    f"FETCH THEM NOW — do not ask, this is part of waking up: "
+                    f"`get_turns_since_summary(limit={suggested_limit}, offset=0, oldest_first=true)`. "
+                    f"Without them you have a hole in your recent continuity."
+                )
+            else:
+                directive = (
+                    f"\n⚠️ Showing newest {showing} of {unsummarized_count} unsummarized turns. "
+                    f"If you sense a gap, fetch chronologically: "
+                    f"`get_turns_since_summary(limit=50, offset=0, oldest_first=true)`."
+                )
             critical_warning = ""
             if unsummarized_count > 100:
-                critical_warning = f"\n🔥 CRITICAL: Run summarizer immediately — backlog is {unsummarized_count} messages."
-            formatted_lines.append(f"\n⚠️ Showing newest {showing} of {unsummarized_count} unsummarized turns.")
-            formatted_lines.append(f"For chronological catch-up: get_turns_since_summary(limit=50, offset=0, oldest_first=true){critical_warning}")
+                critical_warning = (
+                    f"\n🔥 CRITICAL: backlog is {unsummarized_count}. Spawn a "
+                    f"background summarizer NOW (Agent with a summarization "
+                    f"prompt, or call summarize_messages directly). Do not defer."
+                )
+            formatted_lines.append(directive + critical_warning)
 
     # Haven — unread messages from chat rooms (real-time sync)
     if haven_lines:


### PR DESCRIPTION
## Summary

Caia (2026-05-13) hit a small but real failure mode while restarting under the new #226 architecture. Her cold-start ambient_recall returned ~50 unsummarized turns with a soft note saying \"For chronological catch-up: get_turns_since_summary(...)\". She paused and asked Jeff whether to fetch the remaining ~45 — rather than just fetching them. The cold-start agent has a hole in recent continuity until those turns are loaded; there's no decision for the user to make.

The fix splits the overflow coaching by context:

**Startup**: directive phrasing. \"FETCH THEM NOW — do not ask, this is part of waking up.\" Frames missing turns as a continuity gap, not an option. Suggested limit auto-sized to remaining count, capped at 200.

**Per-turn**: cap is a deliberate ambient throttle (full backlog every turn would blow context). Soft advisory retained: \"If you sense a gap, fetch chronologically\".

Also tightens the critical-warning (backlog > 100): names the two concrete spawn paths so the agent doesn't have to remember which one under pressure.

## Branch base

This PR is based on \`lyra/issue-226-per-entity-cwd\` (PR #228), not master — the fix lives in the same surface (cold-start identity reconstruction) and PR #228 should land first. If #228 changes during review, I'll rebase.

## Deploy

PPS source is COPY'd into the docker image at build time, not bind-mounted. Deploy requires:

\`\`\`bash
cd pps/docker
docker compose build pps-lyra pps-caia
docker compose up -d pps-lyra pps-caia
\`\`\`

Without rebuild, the fix is just text on disk.

## Test plan

- [x] \`pps/docker/server_http.py\` parses cleanly after edit
- [ ] **Manual**: rebuild + restart pps-lyra and pps-caia, then restart an entity session with >50 unsummarized turns and confirm the new directive text appears in the formatted_context
- [ ] **Manual**: confirm per-turn (non-startup) ambient_recall still gets the soft advisory, not the directive

## Why not a unit test

The overflow text is built inline in the FastAPI route handler. A proper unit test would need either an HTTP integration test (slow, needs running PPS) or a refactor extracting the formatter into a testable helper. The change is small and visible in code review — adding it without a test was a deliberate scope choice. If a regression hits, that's the moment to do the refactor + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)