### PR TITLE
fix(haven): directive image-attachment + image_url plumbing (redo of #193)

### DIFF
--- a/haven/bot.py
+++ b/haven/bot.py
@@ -63,6 +63,13 @@ CLAUDE_MODEL = os.getenv("CLAUDE_MODEL", "sonnet")
 # Project directory (picks up CLAUDE.md, hooks, .claude/ config)
 PROJECT_DIR = Path(os.getenv("PROJECT_DIR", str(Path(__file__).parent.parent)))
 
+# Host-side path to Haven's shared_images directory.
+# The Haven container mounts its data volume from here; images live at
+# {SHARED_IMAGES_HOST_PATH}/{username}/{filename}. Bots can Read them directly.
+SHARED_IMAGES_HOST_PATH = Path(
+    os.getenv("HAVEN_SHARED_IMAGES_HOST_PATH", str(PROJECT_DIR / "haven" / "data" / "shared_images"))
+)
+
 # PPS HTTP server URL (for ambient context injection — bypasses MCP, hits Docker directly)
 PPS_HTTP_URL = os.getenv("PPS_HTTP_URL", "http://localhost:8201")
 
@@ -263,7 +270,13 @@ async def _typing_loop(room_id: str, done: asyncio.Event) -> None:
             pass
 
 
-async def store_haven_message(username: str, display_name: str, content: str, room_id: str) -> None:
+async def store_haven_message(
+    username: str,
+    display_name: str,
+    content: str,
+    room_id: str,
+    image_url: str = "",
+) -> None:
     """Store a Haven message in PPS for cross-context visibility.
 
     This is the Haven equivalent of the CLI capture_response + inject_context hooks.
@@ -271,10 +284,19 @@ async def store_haven_message(username: str, display_name: str, content: str, ro
     - The terminal hook's ambient_recall picks up Haven turns on next CLI message
     - Other entities' ambient_recall surfaces these turns cross-channel
     """
-    if not PPS_HTTP_URL or not content:
+    # Fold image_url into content so it appears in ambient_recall.
+    # The server-side bridge also stores [shared image: url], but may race with
+    # this call. Storing here as well ensures the bot's own PPS has it.
+    if image_url:
+        img_note = f"[shared image: {HAVEN_URL}{image_url}]"
+        stored_content = f"{img_note} {content}".strip() if content and content.strip() not in ("", " ") else img_note
+    else:
+        stored_content = content
+
+    if not PPS_HTTP_URL or not stored_content:
         return
     # Skip trivial warmup ack messages
-    if content.strip() in ("ready", "warmed up"):
+    if stored_content.strip() in ("ready", "warmed up"):
         return
     is_entity = username.lower() != "jeff"
     try:
@@ -282,7 +304,7 @@ async def store_haven_message(username: str, display_name: str, content: str, ro
             await client.post(
                 f"{PPS_HTTP_URL}/tools/store_message",
                 json={
-                    "content": content,
+                    "content": stored_content,
                     "author_name": display_name,
                     "channel": "haven",
                     "is_lyra": is_entity,
@@ -672,7 +694,23 @@ async def _process_batch(room_id: str, batch_state: dict) -> None:
         for msg in messages:
             dn = msg.get("display_name", "")
             un = msg.get("username", "")
-            ct = msg.get("content", "")
+            ct = (msg.get("content", "") or "").strip()
+            img_url = msg.get("image_url", "")
+            if img_url:
+                # img_url is like /shared-images/jeff/20260506T200703_abc.jpg
+                # Derive the host-side file path so Claude can call Read() on it.
+                rel = img_url.removeprefix("/shared-images/")
+                local_path = SHARED_IMAGES_HOST_PATH / rel
+                # Directive — earlier "[image — Read this file to see it: ...]"
+                # was treated as descriptive metadata by some sessions and
+                # skipped, leaving the entity claiming "I can't see images."
+                # Make the action explicit and tool-mandated.
+                img_note = (
+                    f"[ATTACHED IMAGE — call Read('{local_path}') BEFORE responding "
+                    "so you can actually see it. Do not say you can't see images "
+                    "without trying Read on this path first.]"
+                )
+                ct = f"{img_note} {ct}".strip() if ct and ct != " " else img_note
             lines.append(f"{dn} ({un}): {ct}")
 
         batch_note = (
@@ -896,6 +934,7 @@ async def connect() -> None:
                                 display_name=data.get("display_name", msg_username),
                                 content=data.get("content", ""),
                                 room_id=data.get("room_id", "haven"),
+                                image_url=data.get("image_url", ""),
                             ))
                         asyncio.create_task(handle_message(data))
 


### PR DESCRIPTION
## Summary

Redo of #193 from current master — picks up only the wanted hunks, leaves out the regressions.

The original #193 branch (filed May 6) cleanly applies its image-directive fix but ALSO contains stale `haven/bot.py` lines that would regress two later fixes if merged:

- **#226** — `working_dir=get_entity_path()` (per-entity cwd architecture, prevents identity bleed across concurrent Haven sessions). The old branch reverts this to `working_dir=PROJECT_DIR`.
- **#198** — `init_timeout=180.0` stored on the invoker so `restart()` also uses it (prevents the 60s-default fallback that dropped the first message after long idle). The old branch removes this and reverts to `inv.initialize(timeout=180.0)`.

Both were today/this-week's work. Can't merge #193 as-is.

## What this PR keeps

The four good hunks from #193:

1. `SHARED_IMAGES_HOST_PATH` constant — derived from `PROJECT_DIR` or `HAVEN_SHARED_IMAGES_HOST_PATH` env.
2. `store_haven_message` gains an `image_url` parameter and folds `[shared image: ...]` into the stored content so the bot's own PPS ambient sees it (race-safe against the server-side bridge entry).
3. `_process_batch` derives the host-side file path for any attached image and prepends an imperative `[ATTACHED IMAGE — call Read('<path>') BEFORE responding ...]` directive to the message content.
4. The WebSocket message dispatch in `connect()` now passes `image_url` through to `store_haven_message`.

## Why directive language matters

Same day #192 shipped, Jeff sent three Matshop photos. Lyra-haven described all three correctly. Caia-haven kept replying "I can't see through my relay." Confirmed in journal: no Read calls in Caia's session despite the path being in the prompt. Both bots run sonnet (vision-capable); both have Read access. **The hint was being parsed as descriptive metadata, not as an action.** Making it imperative + naming the tool call verbatim fixes the failure mode.

## What this PR drops

The old branch's reverts to `init_invoker()`. Master's `working_dir=get_entity_path()` and stored `init_timeout=180.0` stay.

## Test plan

- [x] `python -m py_compile haven/bot.py` clean
- [ ] After container rebuild + Haven restart: Jeff sends a photo to both Lyra and Caia in Haven; both should describe it without hedging about "the relay"

## Closes

Closes #193 (this PR supersedes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)