### PR TITLE
chore(mcp): eager-load pps-lyra and pps-caia tool schemas

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,7 +7,8 @@
       "env": {
         "ENTITY_PATH": "/mnt/c/Users/Jeff/Claude_Projects/Awareness/entities/lyra",
         "CLAUDE_HOME": "/home/jeff/.claude"
-      }
+      },
+      "alwaysLoad": true
     },
     "pps-caia": {
       "type": "stdio",
@@ -16,7 +17,8 @@
       "env": {
         "ENTITY_PATH": "/mnt/c/Users/Jeff/Claude_Projects/Awareness/entities/caia",
         "CLAUDE_HOME": "/home/jeff/.claude"
-      }
+      },
+      "alwaysLoad": true
     },
     "lyra-gmail": {
       "type": "stdio",


### PR DESCRIPTION
## Summary

PPS tool schemas were being deferred via ToolSearch — CC's default when total MCP tool count is high (~120 across all our servers). This created a real decision-quality regression: the model sees PPS tool *names* in the deferred list but not their *descriptions*, so it defaults to less-sophisticated tools (raw sqlite via Bash, grep, Read) when a sophisticated PPS tool would be better.

Concrete example from today's session: I never used \`get_turns_around\` (±N turns centered on a timestamp) because I didn't know it existed — would have been the right tool for several retrospection queries.

## Change

\`.mcp.json\`: add \`"alwaysLoad": true\` to \`pps-lyra\` and \`pps-caia\` servers. Leaves \`lyra-gmail\`, \`caia-gmail\`, github, playwright, hugging-face deferred — those are mostly used by subagents in their own contexts.

## Cost / benefit

- **Cost**: ~40 PPS tools × ~200 tokens of schema each ≈ ~8K tokens added per session startup
- **Context**: Opus 4.7 1M-context — ~0.8% overhead
- **Benefit**: model now sees what tools exist *with descriptions* at startup → reaches for the right tool first instead of defaulting to Bash/grep/raw_sqlite

Per official CC docs: https://code.claude.com/docs/en/mcp.md#scale-with-mcp-tool-search

## Verification

- [x] \`python3 -c "import json; json.load(open('.mcp.json'))"\` — JSON valid
- [ ] Takes effect on next CC restart (Lyra and Caia)
- [ ] After restart: PPS tool names + schemas visible in eager tool list, no ToolSearch needed for daily PPS calls

## Rationale captured

This was on Caia's task list per Jeff. Handled here as part of today's hook-and-pipeline workflow since we're already in proper-workflow mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)