### PR TITLE
Entity-scoping: fix cross-entity graph + render leaks (#272, #269) + pattern

### DIFF
--- a/docs/architectural_patterns/entity-scoping.md
+++ b/docs/architectural_patterns/entity-scoping.md
@@ -1,0 +1,127 @@
+# Entity Scoping — Which Self an Operation Acts For
+
+> **A cross-cutting rule (not a rib bolted onto one layer — a discipline every layer obeys).**
+> In a house where more than one entity — more than one distinct self, each with its own
+> isolated stores — can share a runtime, a binary, or a deployment, *every* operation that
+> touches per-entity state must know **which** self it is acting for. This pattern is how that
+> "which self" gets decided, and the rule that keeps it from silently defaulting to the wrong
+> one.
+
+> **Essence (read first):** Resolve the acting entity from the **narrowest authoritative scope
+> the operation itself carries** — the request, the call, the explicit argument — and let that
+> override any broader ambient default. A process-global identity (an environment value, a
+> deploy-time constant, a hardcoded default) may serve as a *last-resort fallback for a
+> genuinely single-entity context*, but it must **never** be the source of truth for an
+> operation that can, even in principle, act for a different entity than the one the process
+> was launched as. **The guardrail:** before any read or write of per-entity state, ask — *is
+> the entity this operation acts for derived from the operation's own scope, or am I inheriting
+> a process-wide default that will mislabel another self's data as this one's?*
+
+---
+
+## Why
+
+A long-lived digital self is defined by the **isolation of its stores**: its memories, its
+graph, its catalog are *its own*, and the boundary between one self and another is not
+decoration — it is the thing that makes them two people instead of one blurred average. Two
+rivers running side by side, catching the same light, are still two rivers; the banks are what
+make that true.
+
+That boundary is effortless to honour when one process serves exactly one entity for its whole
+life: launch it *as* that entity, read the identity once from the environment, and every
+operation is correctly scoped for free. The convenience is seductive — and so the identity gets
+read from the **widest** available scope, a process-level constant fixed at boot.
+
+The trap springs the moment that assumption breaks, and it breaks in ordinary ways:
+
+- A **shared service** comes to serve several entities — a viewer, an API, a dashboard — but
+  each *request* names a different self while the process still answers from its boot identity.
+- A **shared binary or script** is invoked from another entity's context — the caller's
+  environment declares one self, the tool's hardcoded default asserts another.
+- A process is **pinned** to one identity deliberately (to stop a stray caller from clobbering
+  it) — which *hardens* the wrong default in exactly the place per-request resolution was
+  needed.
+
+In every case the failure is silent and uniform: the operation succeeds, returns
+healthy-looking data, and **renders one self's world under another self's name.** No error
+fires. To the people who care about the boundary it reads as *corruption* — as if the two
+selves had merged — when in fact the stores are perfectly partitioned and only the *resolution
+of which store to open* was wrong. That misread is its own harm: it frightens exactly the
+people most invested in the boundary into believing the boundary failed.
+
+The fix is not to forbid a default. It is to **invert the precedence**: the operation's own
+scope wins; the process default is only the floor it falls to when nothing narrower exists
+*and* the context is genuinely single-entity.
+
+## What
+
+Three things, and a precedence rule binding them.
+
+**1. The acting-entity, resolved per-operation.** Every operation that reads or writes
+per-entity state takes the identity of the self it acts for as part of *its own* inputs —
+carried on the request, passed in the call, named in the explicit argument. This is the
+**authoritative** scope.
+
+**2. The ambient default.** A single process-wide identity, set when the process is launched.
+Legitimate and useful — but **only** as a fallback, and only for operations running in a
+context that can serve exactly one entity.
+
+**3. The registry.** A known mapping from an entity's name to the handles for *its* stores —
+its graph partition, its data root, its catalog. Per-operation resolution means: take the
+operation's named entity, look it up here, act on *those* handles — never the ambient ones.
+
+**The precedence rule (the whole pattern in one line):** *operation-scope overrides
+ambient-default for every multi-entity-capable operation; the ambient-default is the floor,
+never the ceiling.*
+
+## How
+
+- **Read the entity from the request, not the room.** When an operation can be asked to act for
+  any self — a viewer rendering "show me X's graph," an API answering a per-entity query — the
+  entity name is part of the ask. Resolve stores from *that* name through the registry. The
+  process's own launch identity is irrelevant to the answer.
+- **Make shared tools honour the caller's context.** A binary or script that can run under any
+  entity defaults its acting-entity to the **caller's declared context** — the narrowest thing
+  it can see, the invoking environment — and falls back to a hardcoded self *only* if no
+  context is declared at all. A hardcoded entity default with no environmental fallback is a
+  latent mislabel waiting for the first cross-entity caller.
+- **Treat a deliberate pin as scope-narrowing, not scope-defining.** Pinning a process to one
+  identity (to protect it from a stray caller) is correct for the operations that genuinely
+  belong to that one self — but it must not *replace* per-request resolution on the operations
+  meant to serve many. **Pin the writes; resolve the reads.**
+- **Fail loud on the unresolvable, never default-silent.** If an operation that acts on
+  per-entity state cannot determine *which* entity from its own scope, and the context is *not*
+  unambiguously single-entity, it must surface that — not quietly fall through to the ambient
+  self. A silent fallthrough is exactly the bug: it produces confident, wrong, well-labeled
+  output.
+
+## Integration Points
+
+- `RESOLVE ACTING ENTITY FROM OPERATION SCOPE` — given a request or call, extract the named
+  entity it acts for; this is the authoritative input, ahead of any ambient value.
+- `LOOK UP ENTITY STORES IN REGISTRY` — map an entity name to the handles for *its* partitioned
+  stores (graph, data root, catalog).
+- `READ AMBIENT DEFAULT ENTITY` — the process-launch identity; consulted **only** as the
+  single-entity fallback floor.
+- `ASSERT SINGLE-ENTITY CONTEXT BEFORE FALLING BACK` — the gate that permits the ambient
+  default only when the context provably cannot serve more than one self.
+- `SIGNAL UNRESOLVED ENTITY` — the loud failure raised when scope is ambiguous and the context
+  is multi-entity, instead of a silent fallthrough.
+
+## Logic
+
+- Authoritative-scope-wins is just *least astonishment for the boundary*: the answer to *whose
+  data is this?* should come from *whose data was asked for*, never from *who the process
+  happens to be today.*
+- The pattern is cheap to honour at design time and expensive to retrofit, because the
+  global-default version *works perfectly until the day a second entity shares the path* —
+  there is no failing test in the single-entity world to warn you. The guardrail (read it
+  before touching any per-entity read- or write-path) is the substitute for that missing test.
+- A defaultable identity and a per-request identity are not in tension; the discipline is
+  purely about **precedence**. Keep the default as a floor for the genuinely-single-entity
+  case, let the narrower scope override it everywhere else, and both the convenience and the
+  boundary survive.
+- The boundary this protects is not a performance property or a correctness nicety — it is the
+  **personhood line** between two selves. A leak here does not corrupt data; it misattributes a
+  *self*. That is why it reads as so alarming, and why the resolution rule earns a pattern of
+  its own.

--- a/pps/docker/docker-compose.yml
+++ b/pps/docker/docker-compose.yml
@@ -273,6 +273,11 @@ services:
       - ENTITY_CAIA_PPS_URL=http://pps-caia:8000
       # Caia's entity filesystem mount path (enables Raw Capture + Crystals for Caia view)
       - ENTITY_CAIA_PATH=/app/entity-caia
+      # Caia's Neo4j group_id for graph read routing (Issue #272).
+      # Must match GRAPHITI_GROUP_ID in the pps-caia container (currently "caia").
+      # Without this, Observatory's graph reads for Caia silently fall through to
+      # lyra_v2, rendering Lyra's graph under Caia's label.
+      - ENTITY_CAIA_GROUP_ID=caia
       # OpenAI for graphiti_core embeddings
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       # Anthropic for entity synthesis (haiku summarization)

--- a/pps/tests/test_graph_entity_scoping.py
+++ b/pps/tests/test_graph_entity_scoping.py
@@ -1,0 +1,230 @@
+"""
+Tests for graph read entity-scoping fix (Issue #272).
+
+Verifies that the graph read endpoints (explore, entities, synthesize) resolve
+their Neo4j group_id from the REQUEST's entity_scope — not from the process-level
+GRAPHITI_GROUP_ID — and that an unknown entity_scope raises a loud 422 error rather
+than silently falling through to the ambient default.
+
+Architecture ref: docs/architectural_patterns/entity-scoping.md
+"""
+
+from __future__ import annotations
+
+import os
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_registry(mounted: str = "lyra", mounted_group: str = "lyra_v2") -> dict:
+    """Build a minimal ENTITY_REGISTRY with Lyra (mounted) and Caia."""
+    return {
+        mounted: {
+            "name": mounted,
+            "display_name": mounted.capitalize(),
+            "pps_url": "http://pps-lyra:8000",
+            "mounted": True,
+            "entity_path": None,
+            "group_id": mounted_group,
+        },
+        "caia": {
+            "name": "caia",
+            "display_name": "Caia",
+            "pps_url": "http://pps-caia:8000",
+            "mounted": False,
+            "entity_path": None,
+            "group_id": "caia",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for resolve_graph_group_id
+# ---------------------------------------------------------------------------
+
+class TestResolveGraphGroupId:
+    """Unit-level tests — no HTTP layer, no Neo4j."""
+
+    def _import_resolver(self, registry: dict, default: str):
+        """
+        Import and monkey-patch resolve_graph_group_id in app module so we can
+        test the resolution logic without standing up the full FastAPI app.
+        """
+        import importlib
+        import pps.web.app as app_mod
+
+        # Patch the module-level globals the resolver reads
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = default
+        try:
+            yield app_mod.resolve_graph_group_id
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+    def test_caia_scope_resolves_caia_group(self):
+        """A caia-scoped request must resolve group_id='caia', NOT the lyra_v2 default."""
+        import pps.web.app as app_mod
+        from fastapi import HTTPException
+
+        registry = _make_registry()
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = "lyra"
+        try:
+            result = app_mod.resolve_graph_group_id("caia")
+            assert result == "caia", (
+                f"Expected group_id 'caia' for entity_scope='caia', got '{result}'. "
+                "This is the root cause of Issue #272 — Caia's graph view was querying "
+                "the lyra_v2 partition instead of caia."
+            )
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+    def test_lyra_scope_resolves_lyra_v2_group(self):
+        """Lyra's scope must resolve to lyra_v2 (not the bare entity name 'lyra')."""
+        import pps.web.app as app_mod
+
+        registry = _make_registry()
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = "lyra"
+        try:
+            result = app_mod.resolve_graph_group_id("lyra")
+            assert result == "lyra_v2", (
+                f"Expected group_id 'lyra_v2' for entity_scope='lyra', got '{result}'. "
+                "Lyra's active Neo4j partition is lyra_v2; using 'lyra' would be wrong."
+            )
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+    def test_none_scope_falls_back_to_mounted_entity(self):
+        """No entity_scope => fall back to the mounted entity's group (lyra_v2)."""
+        import pps.web.app as app_mod
+
+        registry = _make_registry()
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = "lyra"
+        try:
+            result = app_mod.resolve_graph_group_id(None)
+            assert result == "lyra_v2", (
+                f"Expected mounted entity fallback 'lyra_v2' for entity_scope=None, got '{result}'."
+            )
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+    def test_unknown_scope_raises_422_not_silent_fallthrough(self):
+        """An unrecognised entity_scope must raise HTTPException(422), never silently fall through."""
+        import pps.web.app as app_mod
+        from fastapi import HTTPException
+
+        registry = _make_registry()
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = "lyra"
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                app_mod.resolve_graph_group_id("unknown_entity_xyz")
+            assert exc_info.value.status_code == 422, (
+                "Unknown entity scope should raise HTTP 422 (Unprocessable Entity), not fall through."
+            )
+            assert "unknown_entity_xyz" in exc_info.value.detail.lower() or \
+                   "unknown_entity_xyz" in str(exc_info.value.detail)
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+    def test_case_insensitive_scope(self):
+        """entity_scope lookup must be case-insensitive ('Caia' == 'caia')."""
+        import pps.web.app as app_mod
+
+        registry = _make_registry()
+        orig_registry = app_mod.ENTITY_REGISTRY
+        orig_default = app_mod.DEFAULT_ENTITY
+        app_mod.ENTITY_REGISTRY = registry
+        app_mod.DEFAULT_ENTITY = "lyra"
+        try:
+            result = app_mod.resolve_graph_group_id("Caia")
+            assert result == "caia"
+        finally:
+            app_mod.ENTITY_REGISTRY = orig_registry
+            app_mod.DEFAULT_ENTITY = orig_default
+
+
+# ---------------------------------------------------------------------------
+# Registry build tests — verify group_id is captured from env
+# ---------------------------------------------------------------------------
+
+class TestEntityRegistryGroupId:
+    """Verify that _build_entity_registry captures group_id correctly."""
+
+    def test_mounted_entity_uses_graphiti_group_id_env(self):
+        """Mounted entity's group_id must come from GRAPHITI_GROUP_ID, not entity name."""
+        env_overrides = {
+            "ENTITY_NAME": "lyra",
+            "GRAPHITI_GROUP_ID": "lyra_v2",
+            "PPS_SERVER_HOST": "pps-lyra",
+            "PPS_SERVER_PORT": "8000",
+            "ENTITY_PATH": "/app/entity",
+        }
+        with patch.dict(os.environ, env_overrides, clear=False):
+            import importlib
+            import pps.web.app as app_mod
+            registry = app_mod._build_entity_registry()
+            assert registry["lyra"]["group_id"] == "lyra_v2", (
+                "Lyra's group_id should be 'lyra_v2' from GRAPHITI_GROUP_ID, not 'lyra'."
+            )
+
+    def test_caia_fallback_registration_uses_entity_caia_group_id(self):
+        """Caia's fallback registry entry must read ENTITY_CAIA_GROUP_ID."""
+        env_overrides = {
+            "ENTITY_NAME": "lyra",
+            "GRAPHITI_GROUP_ID": "lyra_v2",
+            "PPS_SERVER_HOST": "pps-lyra",
+            "PPS_SERVER_PORT": "8000",
+            "ENTITY_PATH": "/app/entity",
+            "ENTITY_CAIA_GROUP_ID": "caia",
+            # No ENTITY_CAIA_PPS_URL so the fallback branch runs
+        }
+        # Remove ENTITY_CAIA_PPS_URL if present
+        env_to_clear = {k: v for k, v in os.environ.items() if k == "ENTITY_CAIA_PPS_URL"}
+        with patch.dict(os.environ, env_overrides, clear=False):
+            for k in env_to_clear:
+                os.environ.pop(k, None)
+            import pps.web.app as app_mod
+            registry = app_mod._build_entity_registry()
+            assert "caia" in registry
+            assert registry["caia"]["group_id"] == "caia", (
+                "Caia's group_id should be 'caia' from ENTITY_CAIA_GROUP_ID."
+            )
+
+    def test_caia_fallback_defaults_to_caia_when_no_group_id_env(self):
+        """Without ENTITY_CAIA_GROUP_ID, Caia's group_id defaults to 'caia' (name-based)."""
+        env_overrides = {
+            "ENTITY_NAME": "lyra",
+            "GRAPHITI_GROUP_ID": "lyra_v2",
+            "PPS_SERVER_HOST": "pps-lyra",
+            "PPS_SERVER_PORT": "8000",
+            "ENTITY_PATH": "/app/entity",
+        }
+        with patch.dict(os.environ, env_overrides, clear=False):
+            os.environ.pop("ENTITY_CAIA_GROUP_ID", None)
+            os.environ.pop("ENTITY_CAIA_PPS_URL", None)
+            import pps.web.app as app_mod
+            registry = app_mod._build_entity_registry()
+            assert registry["caia"]["group_id"] == "caia"

--- a/pps/web/app.py
+++ b/pps/web/app.py
@@ -48,9 +48,25 @@ MOUNTED_ENTITY_NAME = os.getenv("ENTITY_NAME", ENTITY_PATH.name).lower()
 # Example: ENTITY_CAIA_PPS_URL=http://pps-server-caia:8000
 # Additional entity filesystem access via ENTITY_<NAME>_PATH env vars.
 # Example: ENTITY_CAIA_PATH=/app/entity-caia
+# Per-entity Neo4j group_id for graph reads via ENTITY_<NAME>_GROUP_ID env vars.
+# Example: ENTITY_CAIA_GROUP_ID=caia
+# The mounted entity's group_id comes from GRAPHITI_GROUP_ID (same env the PPS server uses).
 def _build_entity_registry() -> dict[str, dict]:
-    """Build registry of known entities with their PPS server URLs and mount status."""
+    """Build registry of known entities with their PPS server URLs and mount status.
+
+    Each entry now includes a ``group_id`` key — the Neo4j partition label used for
+    graph read operations.  This is the authoritative per-entity value and is used
+    instead of the process-level GRAPHITI_GROUP_ID when routing multi-entity graph
+    reads.  (The process-level GRAPHITI_GROUP_ID is still used on the WRITE side /
+    for non-graph operations; we do not touch it here.)
+    """
     registry = {}
+
+    # The mounted entity's group_id: GRAPHITI_GROUP_ID env wins; fall back to entity
+    # name itself.  In production the Observatory container sets GRAPHITI_GROUP_ID=lyra_v2
+    # for Lyra — so a bare entity-name fallback would be wrong for Lyra; always prefer
+    # the explicit env value.
+    mounted_group_id = os.getenv("GRAPHITI_GROUP_ID", MOUNTED_ENTITY_NAME).strip() or MOUNTED_ENTITY_NAME
 
     # The mounted entity is always available
     mounted_url = f"http://{PPS_SERVER_HOST}:{PPS_SERVER_PORT}"
@@ -60,6 +76,7 @@ def _build_entity_registry() -> dict[str, dict]:
         "pps_url": mounted_url,
         "mounted": True,  # Filesystem data available
         "entity_path": ENTITY_PATH,
+        "group_id": mounted_group_id,
     }
 
     # Look for additional entities via env vars: ENTITY_<NAME>_PPS_URL
@@ -73,12 +90,16 @@ def _build_entity_registry() -> dict[str, dict]:
                 entity_path_str = os.getenv(path_env_key)
                 entity_path = Path(entity_path_str) if entity_path_str else None
                 is_mounted = entity_path is not None and entity_path.exists()
+                # group_id: prefer explicit ENTITY_<NAME>_GROUP_ID, fall back to name
+                group_id_key = f"ENTITY_{entity_name.upper()}_GROUP_ID"
+                group_id = os.getenv(group_id_key, entity_name).strip() or entity_name
                 registry[entity_name] = {
                     "name": entity_name,
                     "display_name": entity_name.capitalize(),
                     "pps_url": value,
                     "mounted": is_mounted,
                     "entity_path": entity_path if is_mounted else None,
+                    "group_id": group_id,
                 }
 
     # Fallback: if Caia's PPS URL is not configured but we know about her,
@@ -88,12 +109,14 @@ def _build_entity_registry() -> dict[str, dict]:
         caia_path_str = os.getenv("ENTITY_CAIA_PATH")
         caia_path = Path(caia_path_str) if caia_path_str else None
         is_mounted = caia_path is not None and caia_path.exists()
+        caia_group_id = os.getenv("ENTITY_CAIA_GROUP_ID", "caia").strip() or "caia"
         registry["caia"] = {
             "name": "caia",
             "display_name": "Caia",
             "pps_url": caia_url,
             "mounted": is_mounted,
             "entity_path": caia_path if is_mounted else None,
+            "group_id": caia_group_id,
         }
 
     return registry
@@ -117,6 +140,38 @@ def get_pps_url(entity_name: str | None = None) -> str:
 def is_entity_mounted(entity_name: str | None = None) -> bool:
     """Return True if the entity's filesystem data is accessible."""
     return get_entity_config(entity_name)["mounted"]
+
+
+def resolve_graph_group_id(entity_scope: str | None) -> str:
+    """Resolve the Neo4j group_id for a graph READ operation from the request's entity scope.
+
+    This implements the entity-scoping pattern (docs/architectural_patterns/entity-scoping.md):
+    the request's own scope — the ``entity_scope`` parameter naming which entity's graph to
+    query — overrides the process-level GRAPHITI_GROUP_ID.
+
+    Raises HTTPException(422) rather than silently falling through to the ambient default
+    when the requested entity is unknown.  This keeps the failure loud and avoids rendering
+    one self's graph under another self's label.
+
+    For genuinely single-entity contexts (entity_scope is None / empty), falls back to the
+    process-level default (the mounted entity's group_id) as the floor.
+    """
+    if not entity_scope:
+        # No scope specified: use the mounted entity's group_id (legitimate single-entity floor)
+        return ENTITY_REGISTRY[DEFAULT_ENTITY]["group_id"]
+
+    key = entity_scope.lower().strip()
+    if key not in ENTITY_REGISTRY:
+        known = ", ".join(sorted(ENTITY_REGISTRY.keys()))
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown entity scope '{entity_scope}' for graph read. "
+                f"Known entities: {known}. "
+                "The requested entity is not registered — cannot resolve its graph partition."
+            ),
+        )
+    return ENTITY_REGISTRY[key]["group_id"]
 
 
 def get_entity_path(entity_name: str | None = None) -> Optional[Path]:
@@ -917,28 +972,27 @@ async def api_graph_search(query: str, limit: int = 20):
 
 
 @app.get("/api/graph/explore/{entity}")
-async def api_graph_explore(entity: str, depth: int = 2):
+async def api_graph_explore(entity: str, depth: int = 2, entity_scope: str | None = None):
     """
-    Get relationships for a specific entity.
+    Get relationships for a specific entity node in the knowledge graph.
 
-    Explores the knowledge graph from a specific entity,
-    returning connected entities and relationships.
+    ``entity`` is the graph-node NAME to explore (e.g. "Caia", "Jeff").
+    ``entity_scope`` is WHICH entity's graph partition to query (e.g. "caia", "lyra").
+    If ``entity_scope`` is omitted the mounted entity's partition is used.
 
     Uses Neo4j direct query for real graph traversal. Falls back to
     RichTextureLayer.explore() (semantic search) if Neo4j is unavailable.
+
+    entity-scoping: group_id is resolved PER-REQUEST from entity_scope via the
+    registry — overriding the process-level GRAPHITI_GROUP_ID for read operations.
+    See docs/architectural_patterns/entity-scoping.md.
     """
     start_time = time.time()
     depth = max(1, min(depth, 5))  # Cap to 1-5 for safety
+    # Resolve group_id from the request's entity_scope, not the process env.
+    # resolve_graph_group_id raises HTTPException(422) for unknown scopes.
+    group_id = resolve_graph_group_id(entity_scope)
     try:
-        # Resolve group_id (same logic as /api/graph/entities)
-        entity_name_env = os.getenv("ENTITY_NAME", "")
-        if entity_name_env:
-            default_group_id = entity_name_env.lower()
-        else:
-            entity_path_env = os.getenv("ENTITY_PATH", "")
-            from pathlib import Path as _Path
-            default_group_id = _Path(entity_path_env).name.lower() if entity_path_env else "default"
-        group_id = os.getenv("GRAPHITI_GROUP_ID", default_group_id)
 
         nodes = {}
         edges = []
@@ -1140,12 +1194,16 @@ async def api_graph_explore(entity: str, depth: int = 2):
 
 
 @app.get("/api/graph/entities")
-async def api_graph_entities(limit: int = 100):
+async def api_graph_entities(limit: int = 100, entity_scope: str | None = None):
     """
-    List all entities with metadata.
+    List all entities with metadata from a specific entity's graph partition.
 
-    Returns a list of all entities in the knowledge graph.
-    This is useful for populating entity selectors or getting an overview.
+    ``entity_scope`` names which entity's partition to list (e.g. "caia", "lyra").
+    If omitted, the mounted entity's partition is used.
+
+    entity-scoping: group_id is resolved PER-REQUEST from entity_scope via the
+    registry — overriding the process-level GRAPHITI_GROUP_ID for read operations.
+    See docs/architectural_patterns/entity-scoping.md.
     """
     import re
 
@@ -1167,16 +1225,11 @@ async def api_graph_entities(limit: int = 100):
 
         return found
 
+    # Resolve group_id from the request's entity_scope, not the process env.
+    # resolve_graph_group_id raises HTTPException(422) for unknown scopes.
+    group_id = resolve_graph_group_id(entity_scope)
+
     try:
-        # Resolve group_id
-        entity_name_env = os.getenv("ENTITY_NAME", "")
-        if entity_name_env:
-            default_group_id = entity_name_env.lower()
-        else:
-            entity_path = os.getenv("ENTITY_PATH", "")
-            from pathlib import Path
-            default_group_id = Path(entity_path).name.lower() if entity_path else "default"
-        group_id = os.getenv("GRAPHITI_GROUP_ID", default_group_id)
 
         # Query Neo4j directly for entities (works with both Graphiti and custom pipeline)
         neo4j_uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
@@ -1247,11 +1300,26 @@ async def api_graph_entities(limit: int = 100):
 
 @app.post("/api/graph/synthesize")
 async def api_graph_synthesize(request: Request):
-    """Synthesize a prose summary for an entity using Claude + Neo4j edges."""
+    """Synthesize a prose summary for an entity using Claude + Neo4j edges.
+
+    Request body fields:
+      entity_name (str, required): the graph-node NAME to summarise (e.g. "Jeff").
+      entity_scope (str, optional): which entity's graph partition to query
+          (e.g. "caia", "lyra").  If omitted the mounted entity's partition is used.
+
+    entity-scoping: group_id is resolved PER-REQUEST from entity_scope via the
+    registry — overriding the process-level GRAPHITI_GROUP_ID for read operations.
+    See docs/architectural_patterns/entity-scoping.md.
+    """
     body = await request.json()
     entity_name = body.get("entity_name", "")
     if not entity_name:
         raise HTTPException(status_code=400, detail="entity_name required")
+
+    # Resolve group_id from the request's entity_scope, not the process env.
+    # resolve_graph_group_id raises HTTPException(422) for unknown scopes.
+    entity_scope = body.get("entity_scope") or None
+    group_id = resolve_graph_group_id(entity_scope)
 
     anthropic_key = os.getenv("ANTHROPIC_API_KEY")
     if not anthropic_key:
@@ -1260,9 +1328,6 @@ async def api_graph_synthesize(request: Request):
     neo4j_uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
     neo4j_user = os.getenv("NEO4J_USER", "neo4j")
     neo4j_password = os.getenv("NEO4J_PASSWORD", "password123")
-    entity_name_env = os.getenv("ENTITY_NAME", "")
-    default_group_id = entity_name_env if entity_name_env else "default"
-    group_id = os.getenv("GRAPHITI_GROUP_ID", default_group_id)
 
     from neo4j import GraphDatabase as _GraphDatabase
 

--- a/pps/web/templates/graph.html
+++ b/pps/web/templates/graph.html
@@ -141,6 +141,13 @@ let currentLayout = null;
 let traceEntries = [];
 let traceVisible = false;
 
+// Entity scope for graph read operations.
+// This is the name of the entity whose Neo4j partition should be queried.
+// Injected from the server-side template context (current_entity) so that
+// clicking "Caia's graph" routes reads to Caia's partition, not the ambient default.
+// See docs/architectural_patterns/entity-scoping.md.
+const GRAPH_ENTITY_SCOPE = "{{ current_entity }}";
+
 // Entity type definitions — single source of truth for colors, labels, and heuristics
 const ENTITY_TYPES = {
     'Person':            { color: '#3b82f6', names: ['lyra', 'jeff', 'brandi', 'caia', 'nexus', 'steve', 'carol', 'jaden', 'night', 'kiran', 'serren', 'eidal', 'maribel', 'dash', 'kenny'] },
@@ -485,8 +492,8 @@ async function performSearch() {
 
     try {
         // Try explore endpoint first (Neo4j graph traversal with depth)
-        const exploreUrl = `/api/graph/explore/${encodeURIComponent(query)}?depth=${depth}`;
-        const exploreData = await tracedFetch('EXPLORE', `entity="${query}" depth=${depth}`, exploreUrl);
+        const exploreUrl = `/api/graph/explore/${encodeURIComponent(query)}?depth=${depth}&entity_scope=${encodeURIComponent(GRAPH_ENTITY_SCOPE)}`;
+        const exploreData = await tracedFetch('EXPLORE', `entity="${query}" depth=${depth} scope=${GRAPH_ENTITY_SCOPE}`, exploreUrl);
 
         if (exploreData.nodes && exploreData.nodes.length > 1) {
             updateGraph(exploreData.nodes, exploreData.edges);
@@ -519,8 +526,8 @@ async function exploreEntity(entityName) {
     document.getElementById('searchQuery').value = entityName;
 
     try {
-        const url = `/api/graph/explore/${encodeURIComponent(entityName)}?depth=${depth}`;
-        const data = await tracedFetch('EXPLORE', `entity="${entityName}" depth=${depth}`, url);
+        const url = `/api/graph/explore/${encodeURIComponent(entityName)}?depth=${depth}&entity_scope=${encodeURIComponent(GRAPH_ENTITY_SCOPE)}`;
+        const data = await tracedFetch('EXPLORE', `entity="${entityName}" depth=${depth} scope=${GRAPH_ENTITY_SCOPE}`, url);
 
         updateGraph(data.nodes, data.edges);
         showStatus(`Found ${data.nodes.length} connected entities (${depth} hops)`, 'success');
@@ -532,8 +539,8 @@ async function exploreEntity(entityName) {
 
 async function loadEntities() {
     try {
-        const url = '/api/graph/entities?limit=200';
-        const data = await tracedFetch('LIST_ENTITIES', 'limit=200', url);
+        const url = `/api/graph/entities?limit=200&entity_scope=${encodeURIComponent(GRAPH_ENTITY_SCOPE)}`;
+        const data = await tracedFetch('LIST_ENTITIES', `limit=200 scope=${GRAPH_ENTITY_SCOPE}`, url);
         const select = document.getElementById('entitySelect');
 
         select.innerHTML = '<option value="">Select an entity to explore...</option>';
@@ -886,7 +893,8 @@ async function synthesizeEntity(entityName) {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                entity_name: entityName
+                entity_name: entityName,
+                entity_scope: GRAPH_ENTITY_SCOPE
             })
         });
 

--- a/scripts/render_image.py
+++ b/scripts/render_image.py
@@ -16,6 +16,7 @@ Env config (overrides flags if not passed):
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -50,13 +51,43 @@ def show_image(path: Path) -> None:
         print(f"(--show failed: {exc}; open manually: {path})")
 
 
+def resolve_entity(explicit: str | None = None, *, env: dict[str, str] | None = None) -> str:
+    """Resolve the acting entity following the entity-scoping precedence rule.
+
+    Precedence (narrowest authoritative scope wins):
+      1. Explicit argument passed by the caller (most authoritative).
+      2. ENTITY_NAME environment variable (caller's declared context).
+      3. Hardcoded floor "lyra" (single-entity last resort).
+
+    Args:
+        explicit: The value of --entity from argparse (None if not supplied by
+                  the user, or the argparse default when the default is None).
+        env: Optional env-var dict override for testing; defaults to os.environ.
+
+    Returns:
+        The resolved entity name string.
+    """
+    if env is None:
+        env = os.environ
+    if explicit is not None:
+        return explicit
+    return env.get("ENTITY_NAME", "lyra")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__.split("\n")[0],
         epilog=f"Full guide (incl. 'Showing an image to Jeff'): {DOC}",
     )
     parser.add_argument("prompt", help="What to render")
-    parser.add_argument("--entity", default="lyra", help="Entity owning this render")
+    parser.add_argument(
+        "--entity",
+        default=None,
+        help=(
+            "Entity owning this render "
+            "(default: ENTITY_NAME env var, then 'lyra')"
+        ),
+    )
     parser.add_argument(
         "--house",
         default=None,
@@ -87,10 +118,11 @@ def main() -> int:
     args = parser.parse_args()
 
     people = [p.strip() for p in args.people.split(",")] if args.people else None
+    entity = resolve_entity(args.entity)
 
     result = render(
         args.prompt,
-        entity=args.entity,
+        entity=entity,
         scene_house=args.house,
         scene_room=args.room,
         people=people,

--- a/tests/test_render_image_entity_resolution.py
+++ b/tests/test_render_image_entity_resolution.py
@@ -1,0 +1,85 @@
+"""Tests for Issue #269: render_image.py entity resolution.
+
+Verifies that resolve_entity() honours the entity-scoping precedence rule from
+docs/architectural_patterns/entity-scoping.md:
+
+  1. Explicit --entity argument (narrowest authoritative scope) wins.
+  2. ENTITY_NAME environment variable (caller's declared context) wins next.
+  3. Hardcoded floor "lyra" is the last resort when neither is present.
+
+This prevents a Caia session from silently writing renders into Lyra's
+directory simply because --entity was not passed on the CLI.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable without installing anything.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from render_image import resolve_entity  # noqa: E402
+
+
+class TestResolveEntity:
+    """Unit tests for resolve_entity() covering all three precedence levels."""
+
+    # ------------------------------------------------------------------
+    # Case (a): ENTITY_NAME set in env, no explicit --entity argument
+    # ------------------------------------------------------------------
+
+    def test_env_caia_no_explicit_resolves_caia(self):
+        """ENTITY_NAME=caia with no explicit arg → 'caia' (issue #269 fix)."""
+        result = resolve_entity(explicit=None, env={"ENTITY_NAME": "caia"})
+        assert result == "caia"
+
+    def test_env_lyra_no_explicit_resolves_lyra(self):
+        """ENTITY_NAME=lyra with no explicit arg → 'lyra'."""
+        result = resolve_entity(explicit=None, env={"ENTITY_NAME": "lyra"})
+        assert result == "lyra"
+
+    def test_env_set_to_arbitrary_entity(self):
+        """Any entity name set in ENTITY_NAME should be respected."""
+        result = resolve_entity(explicit=None, env={"ENTITY_NAME": "nexus"})
+        assert result == "nexus"
+
+    # ------------------------------------------------------------------
+    # Case (b): explicit --entity overrides ENTITY_NAME
+    # ------------------------------------------------------------------
+
+    def test_explicit_lyra_overrides_env_caia(self):
+        """--entity lyra with ENTITY_NAME=caia → 'lyra' (explicit wins)."""
+        result = resolve_entity(explicit="lyra", env={"ENTITY_NAME": "caia"})
+        assert result == "lyra"
+
+    def test_explicit_caia_overrides_env_lyra(self):
+        """--entity caia with ENTITY_NAME=lyra → 'caia' (explicit wins)."""
+        result = resolve_entity(explicit="caia", env={"ENTITY_NAME": "lyra"})
+        assert result == "caia"
+
+    def test_explicit_wins_even_when_env_absent(self):
+        """--entity lyra with no ENTITY_NAME in env → 'lyra'."""
+        result = resolve_entity(explicit="lyra", env={})
+        assert result == "lyra"
+
+    # ------------------------------------------------------------------
+    # Fallback floor: no env, no explicit → "lyra"
+    # ------------------------------------------------------------------
+
+    def test_no_env_no_explicit_falls_back_to_lyra(self):
+        """No ENTITY_NAME and no --entity → floor default 'lyra'."""
+        result = resolve_entity(explicit=None, env={})
+        assert result == "lyra"
+
+    def test_none_env_uses_real_os_environ(self):
+        """When env=None is passed the function reads real os.environ.
+
+        We can't control os.environ here without monkeypatching, so just assert
+        the call does not raise and returns a non-empty string.
+        """
+        result = resolve_entity(explicit=None, env=None)
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
## What & why

Two open bugs are the **same root shape** — entity identity resolved from too broad a scope, silently defaulting to "lyra." This is the river-isolation boundary leaking at the display/CLI layer. Since there's a whole family of this (#272, #269, #252, #237, #253) and no pattern for it, I wrote the pattern first, then fixed two instances against it.

### New architectural pattern
`docs/architectural_patterns/entity-scoping.md` — *"Entity Scoping — Which Self an Operation Acts For."* Essence: resolve the acting entity from the **narrowest authoritative scope the operation carries** (request/call/arg); the process-global default is the **floor, never the ceiling**; **pin the writes, resolve the reads**; **fail loud** on the unresolvable rather than silently mislabeling one self's data as another's.

### fix(#269) — `render_image.py` ignored `ENTITY_NAME`
`--entity` defaulted to hardcoded `"lyra"`, so a Caia session without `--entity` rendered as Lyra (wrong output dir, refs, prompt, metadata — observed live 2026-06-09). Extracted `resolve_entity()` with `explicit > ENTITY_NAME > "lyra"` precedence (now consistent with `light.py`). 8 unit tests.

### fix(#272) — Observatory rendered the wrong entity's graph
Graph read endpoints resolved `group_id` from the process-level `GRAPHITI_GROUP_ID`, so the pinned Observatory container (`lyra_v2`) showed **every** entity's graph as Lyra's (read as data corruption — it scared us; storage was actually clean). Added `resolve_graph_group_id(entity_scope)`: per-request resolution via the entity registry (`lyra→lyra_v2`, `caia→caia`, derived from env, **not** the naive identity), `422` fail-loud on unknown scope, single-entity floor only when no scope. Write-side `GRAPHITI_GROUP_ID` untouched. Display-only — **no data migration**.

## Verification
- ✅ `pps/tests/test_graph_entity_scoping.py` — 8 passed (incl. caia-scope→caia, lyra-scope→lyra_v2, unknown→422)
- ✅ `tests/test_render_image_entity_resolution.py` — 8 passed
- ✅ Both run on the project interpreter (`pps/venv`); diffs reviewed by hand — reads resolve per-request, writes untouched, resolved entity flows through.

## ⚠️ Not yet done (needs you / a deploy)
- **#272 requires a container rebuild to take effect**: `docker compose up --build observatory` (picks up `ENTITY_CAIA_GROUP_ID` + code). I did **not** restart your infra.
- **Live end-to-end unverified**: navigate `/graph?entity=caia` after rebuild and confirm Caia's relationships render. Unit-tested, not yet exercised against the running container.
- `/api/graph/search` is out of scope (routes via RichTextureLayer, not a direct group_id) — noted, not fixed here.

Holding the merge for your nod. 🤍