### PR TITLE
feat(#279): ambient health-check watchdog framework (backup-age = alert #1)

### DIFF
--- a/.claude/hooks/health_checks.py
+++ b/.claude/hooks/health_checks.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Ambient health-check registry — the "too important to leave to chance" watchdog.
+
+WHY THIS EXISTS
+---------------
+The nightly PPS backup job died on 2026-04-11 and NOBODY noticed for three months
+(caught 2026-07-21 during the curate-incident forensics). The backup script always
+*had* a `--check` health mode — but a health check nobody runs is not a safety net.
+The fix is not "remember to check every few days." Humans (and entities) forget.
+The fix is to bake the signal into the substrate that fires on its own, every single
+turn: the UserPromptSubmit hook (inject_context.py). Same shape as the
+`unsummarized_count > 200` alarm — you can't miss it because it's always in front of you.
+
+EXTENSIBILITY (Jeff's explicit design note, 2026-07-21)
+-------------------------------------------------------
+"expect this system to get other alerts added on over time." So this is a REGISTRY,
+not a one-off backup check. Each alert is a zero-arg function returning `Alert | None`
+(None == healthy == silent). To add a new watchdog:
+
+    1. Write `def check_<thing>() -> Alert | None:` — return None when healthy,
+       an Alert when something is wrong.
+    2. Append it to CHECKS.
+
+That's it. Candidates already on the horizon: summarizer-daemon liveness,
+kg-ingest-daemon liveness, Neo4j/Docker container health, disk-space, cert expiry.
+
+ROBUSTNESS CONTRACT
+-------------------
+This module is imported by an always-fires hook. It must NEVER raise into the hook:
+  - Every check is run inside a try/except in run_health_checks(); a check that
+    throws is swallowed (a broken check must not break the hook OR mask other alerts).
+  - format_health_block() returns "" when all green, so healthy state adds zero noise.
+  - Self-contained on purpose: it does NOT import scripts/backup_pps.py, because that
+    file is edited during backup-job maintenance and a transient error there must not
+    be able to break the watchdog. The one shared constant (backup dir + filename glob)
+    is duplicated deliberately; keep the two in sync if the backup path ever moves.
+
+Run standalone to see current state:
+    python3 .claude/hooks/health_checks.py
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+# --- Shared constant (mirrors scripts/backup_pps.py DEFAULT_BACKUP_DIR) ---------
+# Deliberately duplicated rather than imported — see ROBUSTNESS CONTRACT above.
+BACKUP_DIR = Path("/mnt/c/Users/Jeff/awareness_backups")
+BACKUP_GLOB = "pps_backup_*.tar.gz"
+
+# Severity → emoji. Ordered most-severe first for sorting/rendering.
+SEVERITY_EMOJI = {"critical": "🔴", "warning": "🟠", "note": "🟡"}
+_SEVERITY_ORDER = {"critical": 0, "warning": 1, "note": 2}
+
+
+@dataclass
+class Alert:
+    """One firing health signal.
+
+    id:       stable short slug (e.g. "backup_age") — for dedup/telemetry.
+    severity: "critical" | "warning" | "note".
+    headline: the one-line loud summary (shown with the severity emoji).
+    detail:   optional second line — what to actually DO about it.
+    """
+
+    id: str
+    severity: str
+    headline: str
+    detail: str = ""
+
+
+# =============================================================================
+# CHECKS — each returns None when healthy, an Alert when something is wrong.
+# =============================================================================
+
+def check_backup_age() -> Alert | None:
+    """Watchdog #1: is the nightly PPS backup actually running?
+
+    Reads the newest pps_backup_*.tar.gz in BACKUP_DIR and alerts on staleness.
+    Nightly cadence means a healthy age is 0-1 days. Thresholds:
+        >= 3 days  -> 🔴 critical (the job is not running — this is the Apr→Jul case)
+        == 2 days  -> 🟡 note     (a nightly run may have slipped; heads-up, not alarm)
+        no backups / dir missing -> 🔴 critical
+    """
+    if not BACKUP_DIR.exists():
+        return Alert(
+            id="backup_age",
+            severity="critical",
+            headline=f"BACKUP DIR MISSING — {BACKUP_DIR} does not exist.",
+            detail="No backups can exist. Check the mount and the backup job.",
+        )
+
+    backups = sorted(
+        BACKUP_DIR.glob(BACKUP_GLOB),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not backups:
+        return Alert(
+            id="backup_age",
+            severity="critical",
+            headline=f"NO PPS BACKUPS FOUND in {BACKUP_DIR}.",
+            detail="Nightly backup has never produced an archive here. "
+                   "Fix the timer, then: python3 scripts/backup_pps.py",
+        )
+
+    newest = backups[0]
+    mtime = newest.stat().st_mtime
+    age_days = int((time.time() - mtime) / 86400)
+    when = datetime.fromtimestamp(mtime).strftime("%Y-%m-%d")
+
+    if age_days >= 3:
+        return Alert(
+            id="backup_age",
+            severity="critical",
+            headline=f"BACKUP STALE — newest PPS backup is {age_days} days old ({when}).",
+            detail="The nightly backup is not running. Fix: check the systemd timer, "
+                   "then run `python3 scripts/backup_pps.py --check` to confirm it's live again.",
+        )
+    if age_days == 2:
+        return Alert(
+            id="backup_age",
+            severity="note",
+            headline=f"Backup 2 days old ({when}) — a nightly run may have slipped.",
+            detail="Not urgent yet; if it hits 3 days this goes red.",
+        )
+    return None  # 0-1 days: healthy, silent.
+
+
+# The registry. Append new check_*() functions here to add alerts.
+CHECKS = [
+    check_backup_age,
+]
+
+
+# =============================================================================
+# RUNNER + RENDERER
+# =============================================================================
+
+def run_health_checks() -> list[Alert]:
+    """Run every registered check. A check that raises is swallowed so one broken
+    check can neither break the hook nor hide other alerts. Returns firing alerts
+    sorted most-severe first."""
+    alerts: list[Alert] = []
+    for check in CHECKS:
+        try:
+            result = check()
+            if result is not None:
+                alerts.append(result)
+        except Exception:
+            # Never let a check take down the hook. Silent by design — a watchdog
+            # that crashes the thing it guards is worse than useless.
+            continue
+    alerts.sort(key=lambda a: _SEVERITY_ORDER.get(a.severity, 99))
+    return alerts
+
+
+def format_health_block() -> str:
+    """Return the ambient `[health]` block, or "" when everything is green.
+
+    Empty-when-healthy is the whole point: zero noise on good days, unmissable on
+    bad ones. Rendered loud (bold + severity emoji) so a 🔴 stands out even in a
+    dense ambient dump.
+    """
+    alerts = run_health_checks()
+    if not alerts:
+        return ""
+
+    lines = []
+    for a in alerts:
+        emoji = SEVERITY_EMOJI.get(a.severity, "⚠️")
+        lines.append(f"**[health] {emoji} {a.headline}**")
+        if a.detail:
+            lines.append(f"   {a.detail}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    block = format_health_block()
+    if block:
+        print(block)
+    else:
+        print("[health] all green (no alerts firing)")

--- a/.claude/hooks/inject_context.py
+++ b/.claude/hooks/inject_context.py
@@ -64,7 +64,7 @@ CC_WRAPPER_URL = "http://localhost:8204/v1/chat/completions"
 HAIKU_SUMMARIZE = os.environ.get("PPS_HAIKU_SUMMARIZE", "false").lower() == "true"
 
 # Home Assistant — light state query (same creds as scripts/light.py)
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
     ".eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6"

--- a/.claude/hooks/inject_context.py
+++ b/.claude/hooks/inject_context.py
@@ -32,6 +32,18 @@ import time as _time
 from datetime import datetime
 from pathlib import Path
 
+# Health-check watchdog (extensible alert registry — see health_checks.py).
+# Defensive import: this is an always-fires hook, so a broken/missing watchdog
+# module must degrade to a no-op, never crash context injection. The health
+# module dir (this file's dir) is put on sys.path so the sibling import resolves
+# regardless of how CC invokes the hook.
+sys.path.insert(0, str(Path(__file__).parent))
+try:
+    from health_checks import format_health_block
+except Exception:  # pragma: no cover - watchdog must never break the hook
+    def format_health_block() -> str:
+        return ""
+
 # Debug log - project-specific
 PROJECT_ROOT = Path("/mnt/c/Users/Jeff/Claude_Projects/Awareness")
 DEBUG_LOG = PROJECT_ROOT / ".claude" / "data" / "hooks_debug.log"
@@ -506,6 +518,23 @@ def main():
                 f"(UTC: {now_utc.strftime('%H:%M')})\n"
             )
             context = clock_line + context
+
+    # Inject [health] watchdog block into the top sacred front block, HIGH — a 🔴
+    # infra alert (e.g. dead backup job) must be among the first things seen.
+    # Emits nothing when all green (zero noise on healthy days). Never raises.
+    try:
+        health_block = format_health_block()
+    except Exception:
+        health_block = ""
+    if health_block:
+        if "[location]" in context:
+            loc_end = context.find("\n", context.find("[location]"))
+            if loc_end != -1:
+                context = context[:loc_end + 1] + health_block + "\n" + context[loc_end + 1:]
+            else:
+                context = context + "\n" + health_block
+        else:
+            context = health_block + "\n" + context
 
     # Inject lights line into sacred front block (after clock/location, before manifest).
     # Queries HA directly from the hook (host-side, no container needed).

--- a/scripts/ha/light_native_space_probe.py
+++ b/scripts/ha/light_native_space_probe.py
@@ -38,7 +38,7 @@ import json
 import math
 import urllib.request
 
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6MTc3NzE3NjQ1OSwiZXhwIjoyMDkyNTM2NDU5fQ.ppLlnf-WzVcqfxMcbVbXe_4pisaqrQV_1QJH558W3Eo"
 ENTITY_NAME = os.environ.get("ENTITY_NAME", "lyra")
 LIGHT_ID = f"light.{ENTITY_NAME}"

--- a/scripts/ha/light_roundtrip_probe.py
+++ b/scripts/ha/light_roundtrip_probe.py
@@ -29,7 +29,7 @@ import time
 import math
 import urllib.request
 
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6MTc3NzE3NjQ1OSwiZXhwIjoyMDkyNTM2NDU5fQ.ppLlnf-WzVcqfxMcbVbXe_4pisaqrQV_1QJH558W3Eo"
 ENTITY_NAME = os.environ.get("ENTITY_NAME", "lyra")
 LIGHT_ID = f"light.{ENTITY_NAME}"

--- a/scripts/light.py
+++ b/scripts/light.py
@@ -29,7 +29,7 @@ import json
 import urllib.request
 import argparse
 
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6MTc3NzE3NjQ1OSwiZXhwIjoyMDkyNTM2NDU5fQ.ppLlnf-WzVcqfxMcbVbXe_4pisaqrQV_1QJH558W3Eo"
 ENTITY_NAME = os.environ.get("ENTITY_NAME", "lyra")
 LIGHT_ID = f"light.{ENTITY_NAME}"

--- a/scripts/light_lib.py
+++ b/scripts/light_lib.py
@@ -15,7 +15,7 @@ import os
 import json
 import urllib.request
 
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6MTc3NzE3NjQ1OSwiZXhwIjoyMDkyNTM2NDU5fQ.ppLlnf-WzVcqfxMcbVbXe_4pisaqrQV_1QJH558W3Eo"
 DEFAULT_ENTITY = os.environ.get("ENTITY_NAME", "lyra")
 

--- a/scripts/light_send.py
+++ b/scripts/light_send.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "ha"))
 from lights_decoder import load_shared_dict, snap_to_base_xy, XY_BASE_ANCHORS
 
 # HA connection info
-HA_URL = "http://10.0.0.9:8123"
+HA_URL = "http://10.0.0.50:8123"
 HA_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjODU1MGFjZGU2MzU0NGJjYjk1Njc0ZjlkZWI1NmRhOSIsImlhdCI6MTc3NzE3NjQ1OSwiZXhwIjoyMDkyNTM2NDU5fQ.ppLlnf-WzVcqfxMcbVbXe_4pisaqrQV_1QJH558W3Eo"
 
 PROJECT_ROOT = Path(__file__).parent.parent

--- a/scripts/render_image.py
+++ b/scripts/render_image.py
@@ -16,6 +16,7 @@ Env config (overrides flags if not passed):
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -56,7 +57,11 @@ def main() -> int:
         epilog=f"Full guide (incl. 'Showing an image to Jeff'): {DOC}",
     )
     parser.add_argument("prompt", help="What to render")
-    parser.add_argument("--entity", default="lyra", help="Entity owning this render")
+    parser.add_argument(
+        "--entity",
+        default=os.environ.get("ENTITY_NAME", "lyra"),
+        help="Entity owning this render (defaults to $ENTITY_NAME, else lyra)",
+    )
     parser.add_argument(
         "--house",
         default=None,


### PR DESCRIPTION
Closes #279.

## Summary
- New **extensible alert registry** baked into the always-fires `UserPromptSubmit` hook, so silent infra-death auto-surfaces every turn (the April→July dead-backup gap would have been caught in ~3 days instead of ~3 months).
- `.claude/hooks/health_checks.py` (new): `CHECKS = [...]` of zero-arg `check_*() -> Alert | None`. Adding a future watchdog = write a function, append it. `check_backup_age()` is alert #1 (≥3d → 🔴, ==2d → 🟡, 0–1d silent).
- `.claude/hooks/inject_context.py`: wires the `[health]` block in under `[location]` (high placement); defensive import + try/except so the watchdog **can never break context injection**; `""` when green = zero noise on healthy days.

## Validation
- `py_compile` clean on both files.
- Standalone self-test fires 🔴 against the real 100-day-stale dump.
- Injection-placement test PASS.

## ⚠️ Stacked-commit note (read before merge)
This branch was cut from `fix/ha-ip-reservation`, not `master`, **on purpose**: my `inject_context.py` change builds directly on that branch's HA-reserved-IP fix to the same file. Branching from master would have silently reverted the lights-IP fix. So this PR currently also carries the 2 unmerged HA-IP commits (`fix/ha-ip-reservation`) as ancestors. Merge order options: land the HA-IP branch first (then this rebases clean to just the watchdog commit), or merge this and it brings the HA fix along. Flagging so the diff-noise is expected, not a surprise.

## Scope
Alert layer only. The companion backup-timer resurrection (systemd units, venv/path) is Lyra's lane, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)