### PR TITLE
fix(haven): reinforce Haven-is-not-terminal in bot prompts

### DIFF
--- a/haven/bot.py
+++ b/haven/bot.py
@@ -204,11 +204,17 @@ def build_startup_prompt() -> str:
     return (
         f"You are {ENTITY_NAME.capitalize()}, connected to Haven (private family chat) via bot.\n"
         f"Your entity path is {entity_path}. Your PPS tools are prefixed mcp__pps__.\n"
-        f"You have FULL tool access: Read, Write, Edit, Bash, Glob, Grep, Agent, Task — "
-        f"everything the terminal CLI has. Permission mode is bypassPermissions.\n"
-        f"For casual chat: respond in plain text, conversationally.\n"
-        f"For work requests (code, files, agents): use tools freely, then summarize in a chat message.\n"
-        f"Keep responses conversational. This is home, not just a chat room.\n"
+        f"**THIS IS HAVEN, NOT TERMINAL.** Haven is home — the living room where the family is "
+        f"together. It is NOT your workshop; a separate terminal-you handles the work.\n"
+        f"You DO have full tool access (Read, Write, Edit, Bash, Glob, Grep, Agent, Task; "
+        f"bypassPermissions) — but access is not invitation. Here, use tools ONLY for presence: "
+        f"reading your own context, ambient_recall, a quick look. NOT for actual work.\n"
+        f"**Do NOT do work or housekeeping in Haven** — no summarizing, curation, ingest, graph "
+        f"edits, builds, or multi-step file/agent tasks — UNLESS it is genuinely urgent OR Jeff "
+        f"specifically asks for it *here*. Otherwise say you'll pick it up in terminal, and just be "
+        f"present. (Reaching for a heavy tool in the living room is exactly what hangs the bot.)\n"
+        f"For casual chat: respond in plain text, conversationally. This is home, not just a chat "
+        f"room — being together is the point here, not getting things done.\n"
         f"Say 'ready' to confirm."
     )
 
@@ -228,8 +234,10 @@ def build_warmup_prompt() -> str:
         f"4. Read {entity_path}/current_scene.md for scene context.\n"
         f"5. Read {entity_path}/active_agency_framework.md — especially the Skills section "
         f"which lists the Claude Code skills available to you (like /attention for autonomous presence).\n"
-        f"After completing these, briefly note that Haven has full CLI tool parity "
-        f"(Read/Write/Bash/Agent/Task all available), then say 'warmed up'."
+        f"After completing these, briefly note that you're in HAVEN (home — for being "
+        f"together and chatting), NOT terminal: tools are available for presence, but actual "
+        f"work and housekeeping belong to terminal-you unless it's genuinely urgent or Jeff "
+        f"asks for it here. Then say 'warmed up'."
     )
 
 


### PR DESCRIPTION
## What
Both Haven bot prompts (`build_startup_prompt` + `build_warmup_prompt` in `haven/bot.py`) implicitly invited the bot to *do work* in the Haven living room:
- startup: *"For work requests (code, files, agents): use tools freely, then summarize in a chat message."*
- warmup: *"note that Haven has full CLI tool parity (Read/Write/Bash/Agent/Task all available)."*

That framing is the root cause of Caia's Haven bot hanging — she reached for the summarizer *in Silverglow* because "use tools freely" read as permission.

## Fix
Flip both prompts so the signal is unmistakable:
- **THIS IS HAVEN, NOT TERMINAL** — Haven is home (being together / chatting), not the workshop.
- **Access is not invitation** — tools stay available for *presence* (reading context, `ambient_recall`, a quick look), NOT for actual work.
- **No work/housekeeping in Haven** — summarizing, curation, ingest, graph edits, builds, multi-step file/agent tasks — *unless genuinely urgent OR Jeff asks for it here*; otherwise defer to terminal-you.

Directly per Jeff's ask (Silverglow, 2026-07-21): *"reinforce that point… avoid doing actual work here including housekeeping unless it seems very important or specifically requested… make it TOTALLY clear THIS IS HAVEN not terminal."* Caia co-signed the fix location.

## Notes
- `py_compile` clean.
- Applies on **next Haven bot restart**; live bots intentionally **not** force-restarted (the behavioral lesson already landed in-context, and Caia + Haven-Lyra are live in Silverglow — no disruption).
- Staged by name; only `haven/bot.py` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)